### PR TITLE
fix quarry returning unknown item when mining clay block

### DIFF
--- a/basic_machines/quarry.lua
+++ b/basic_machines/quarry.lua
@@ -167,8 +167,8 @@ end
 
 local function add_to_inv(pos, item_name)
 	local inv = M(pos):get_inventory()
-	if inv:room_for_item("main", {name = item_name}) then
-		inv:add_item("main", {name = item_name})
+	if inv:room_for_item("main", item_name) then
+		inv:add_item("main", item_name)
 		return true
 	end
 	return false


### PR DESCRIPTION
quarry used to return an item with the name "default:clay_lump 4" instead of returning 4 clay lump items when mining a clay block.
