### PR TITLE
Quarry: Improve digging behaviour

### DIFF
--- a/basis/fake_player.lua
+++ b/basis/fake_player.lua
@@ -1,0 +1,118 @@
+--[[
+
+	TechAge
+	=======
+
+	Copyright (C) 2019-2020 Joachim Stolberg
+	Copyright (C) 2020 Thomas S.
+
+	GPL v3
+	See LICENSE.txt for more information
+
+	Fake Player
+	
+]]--
+
+-- Map method names to their return values
+local methods = {
+	get_pos = { x = 0, y = 0, z = 0 },
+	set_pos = nil,
+	moveto = nil,
+	punch = nil,
+	right_click = nil,
+	get_hp = 20,
+	set_hp = nil,
+	get_inventory = nil,
+	get_wield_list = "",
+	get_wield_index = 0,
+	get_wielded_item = ItemStack(),
+	set_wielded_item = true,
+	set_armor_groups = nil,
+	get_armor_groups = {},
+	set_animation = nil,
+	get_animation = {},
+	set_animation_frame_speed = nil,
+	set_attach = nil,
+	get_attach = nil,
+	set_detach = nil,
+	get_bone_position = {},
+	set_properties = nil,
+	get_properties = {},
+	is_player = false,
+	get_nametag_attributes = {},
+	set_nametag_attributes = nil,
+	get_player_name = "",
+	get_player_velocity = nil,
+	add_player_velocity = nil,
+	get_look_dir = vector.new(0, 0, 1),
+	get_look_vertical = 0,
+	get_look_horizontal = 0,
+	set_look_vertical = nil,
+	set_look_horizontal = nil,
+	get_look_pitch = 0,
+	get_look_yaw = 0,
+	set_look_pitch = nil,
+	set_look_yaw = nil,
+	get_breath = 10,
+	set_breath = nil,
+	set_fov = nil,
+	get_fov = 0,
+	set_attribute = nil,
+	get_attribute = nil,
+	get_meta = nil,
+	set_inventory_formspec = nil,
+	get_inventory_formspec = "",
+	set_formspec_prepend = nil,
+	get_formspec_prepend = "",
+	get_player_control = {},
+	get_player_control_bits = 0,
+	set_physics_override = nil,
+	get_physics_override = {},
+	hud_add = 0,
+	hud_remove = nil,
+	hud_change = nil,
+	hud_get = {},
+	hud_set_flags = nil,
+	hud_get_flags = {},
+	hud_set_hotbar_itemcount = nil,
+	hud_get_hotbar_itemcount = 8,
+	hud_set_hotbar_image = nil,
+	hud_get_hotbar_image = "",
+	hud_set_hotbar_selected_image = nil,
+	hud_get_hotbar_selected_image = "",
+	set_sky = nil,
+	get_sky = {},
+	get_sky_color = {},
+	set_sun = nil,
+	get_sun = {},
+	set_moon = nil,
+	get_moon = {},
+	set_stars = nil,
+	get_stars = {},
+	set_clouds = nil,
+	get_clouds = {},
+	override_day_night_ratio = nil,
+	get_day_night_ratio = nil,
+	set_local_animation = nil,
+	get_local_animation = {},
+	set_eye_offset = nil,
+	get_eye_offset = {},
+	send_mapblock = nil,
+}
+
+techage.Fake_player = {}
+techage.Fake_player.__index = techage.Fake_player
+
+function techage.Fake_player:new()
+	local fake_player = {}
+	setmetatable(fake_player, techage.Fake_player)
+	return fake_player
+end
+
+
+for method_name, return_value in pairs(methods) do
+	techage.Fake_player[method_name] = function(self, ...)
+		return return_value
+	end
+end
+

--- a/digtron/battery.lua
+++ b/digtron/battery.lua
@@ -141,7 +141,7 @@ techage.register_consumer("digtron_battery", S("Digtron Battery"), { act = tiles
 		end
 	end,
 	preserve_metadata = function(pos, oldnode, oldmetadata, drops)
-		metadata = M(pos):to_table()
+		local metadata = M(pos):to_table()
 		if metadata.inventory then
 			local total = count_coal(metadata)
 			local meta = drops[1]:get_meta()

--- a/init.lua
+++ b/init.lua
@@ -66,6 +66,7 @@ end
 -- Basis features
 local MP = minetest.get_modpath("techage")
 dofile(MP.."/basis/lib.lua")  -- helper functions
+dofile(MP.."/basis/fake_player.lua")  -- dummy player object
 dofile(MP.."/basis/node_store.lua")
 dofile(MP.."/basis/gravel_lib.lua")  -- ore probability
 dofile(MP.."/basis/node_states.lua") -- state model

--- a/ta3_power/akkubox.lua
+++ b/ta3_power/akkubox.lua
@@ -120,19 +120,15 @@ local function get_capa(itemstack)
 	return 0
 end
 
-local function set_capa(pos, oldnode, digger, capa)
-	local node = ItemStack(oldnode.name)
-	local meta = node:get_meta()
+local function set_capa(pos, oldnode, oldmetadata, drops)
+	local nvm = techage.get_nvm(pos)
+	local capa = nvm.capa
+	local meta = drops[1]:get_meta()
 	capa = techage.power.percent(PWR_CAPA, capa)
 	capa = (math.floor((capa or 0) / 5)) * 5
 	meta:set_int("capa", capa)
 	local text = S("TA3 Accu Box").." ("..capa.." %)"
 	meta:set_string("description", text)
-	local inv = minetest.get_inventory({type="player", name=digger:get_player_name()})
-	local left_over = inv:add_item("main", node)
-	if left_over:get_count() > 0 then
-		minetest.add_item(pos, node)
-	end
 end
 
 local function after_place_node(pos, placer, itemstack)
@@ -149,9 +145,7 @@ local function after_place_node(pos, placer, itemstack)
 end
 
 local function after_dig_node(pos, oldnode, oldmetadata, digger)
-	local nvm = techage.get_nvm(pos)
 	Cable:after_dig_node(pos)
-	set_capa(pos, oldnode, digger, nvm.capa)
 	techage.del_mem(pos)
 end
 
@@ -188,13 +182,12 @@ minetest.register_node("techage:ta3_akku", {
 	after_dig_node = after_dig_node,
 	tubelib2_on_update2 = tubelib2_on_update2,
 	networks = net_def,
-
-	drop = "", -- don't remove, item will be added via 'set_capa'
 	paramtype2 = "facedir",
 	groups = {cracky=2, crumbly=2, choppy=2},
 	on_rotate = screwdriver.disallow,
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
+	preserve_metadata = set_capa,
 })
 
 Cable:add_secondary_node_names({"techage:ta3_akku"})


### PR DESCRIPTION
Quarry now digs nodes like a player.
Additionally, some possible causes for crashes are fixed.
E.g. the `inv` in the `after_dig_node` callbacks were not guaranteed to exist.

Please note that TA4 batteries that were dug before this change are considered as full.