### PR TITLE
Fixed Gravel Sieve bug

### DIFF
--- a/basic_machines/gravelsieve.lua
+++ b/basic_machines/gravelsieve.lua
@@ -75,20 +75,22 @@ end
 
 local function sieving(pos, crd, nvm, inv)
 	local src, dst
-	if inv:contains_item("src", ItemStack("techage:basalt_gravel")) then
-		dst, src = get_random_basalt_ore(), ItemStack("techage:basalt_gravel")
-	elseif inv:contains_item("src", ItemStack("default:gravel")) then
-		dst, src = get_random_gravel_ore(), ItemStack("default:gravel")
-	else
-		crd.State:idle(pos, nvm)
-		return
+	for i = 1, crd.num_items do
+		if inv:contains_item("src", ItemStack("techage:basalt_gravel")) then
+			dst, src = get_random_basalt_ore(), ItemStack("techage:basalt_gravel")
+		elseif inv:contains_item("src", ItemStack("default:gravel")) then
+			dst, src = get_random_gravel_ore(), ItemStack("default:gravel")
+		else
+			crd.State:idle(pos, nvm)
+			return
+		end
+		if not inv:room_for_item("dst", dst) then
+			crd.State:idle(pos, nvm)
+			return
+		end
+		inv:add_item("dst", dst)
+		inv:remove_item("src", src)
 	end
-	if not inv:room_for_item("dst", dst) then
-		crd.State:idle(pos, nvm)
-		return
-	end
-	inv:add_item("dst", dst)
-	inv:remove_item("src", src)
 	crd.State:keep_running(pos, nvm, COUNTDOWN_TICKS)
 end
 


### PR DESCRIPTION
Fixed a bug with Gravel Sieve. Sieves from all ages processed only 1 gravel every 4 seconds. Now sieves process gravel according to their age. (TA2 - 1 gravel block, TA3 - 2 gravel blocks, TA4 - 4 gravel blocks)