### PR TITLE
Refactor TA4 8x2000 chest

### DIFF
--- a/basis/lib.lua
+++ b/basis/lib.lua
@@ -240,19 +240,15 @@ function techage.is_ocean(pos)
 	return true
 end
 
-function techage.item_image(x, y, itemname)
+function techage.item_image(x, y, itemname, count)
 	local name, size = unpack(string.split(itemname, " "))
+	size = count and count or size
+	size = tonumber(size) or 1
 	local label = ""
-	local tooltip = ""
-	local ndef = minetest.registered_nodes[name] or minetest.registered_items[name] or minetest.registered_craftitems[name]
-	
-	if ndef and ndef.description then
-		local text = minetest.formspec_escape(ndef.description)
-		tooltip = "tooltip["..x..","..y..";1,1;"..text..";#0C3D32;#FFFFFF]"
-	end
-	
-	if ndef and ndef.stack_max == 1 then
-		size = tonumber(size)
+	local text = minetest.formspec_escape(ItemStack(itemname):get_description())
+	local tooltip = "tooltip["..x..","..y..";1,1;"..text..";#0C3D32;#FFFFFF]"
+
+	if minetest.registered_tools[name] and size > 1 then
 		local offs = 0
 		if size < 10 then
 			offs = 0.65


### PR DESCRIPTION
Advantages:
* Code uses common functions for manual usage and automation where possible. This avoids forgetting half of the adjustments like it happened in #14
* Support for meta and wear
* Code duplication for the different automatic modes is reduced/avoided

Additionally, the `techage.item_image` function was adjusted:
* added support meta and wear
* removed duplicate stack size labels for non-tools with max_stack=1
* added optional parameter to "overwrite" stacksize for tools (necessary because of minetest limitations)

I did quite a lot of testing and everything still seems to work fine. However, as always, it is possible that I missed some edge-cases.