### PR TITLE
electrolyzer and growlight fixes

### DIFF
--- a/hydrogen/electrolyzer.lua
+++ b/hydrogen/electrolyzer.lua
@@ -156,6 +156,15 @@ local function after_dig_node(pos, oldnode, oldmetadata, digger)
 	Cable:after_dig_node(pos)
 end
 
+local function put(pos, indir, name, amount)
+	local leftover = liquid.srv_put(pos, indir, name, amount)
+	if techage.is_activeformspec(pos) then
+		local nvm = techage.get_nvm(pos)
+		M(pos):set_string("formspec", formspec(State, pos, nvm))
+	end
+	return leftover
+end
+
 local function tubelib2_on_update2(pos, outdir, tlib2, node) 
 	if tlib2.tube_type == "pipe2" then
 		liquid.update_network(pos, outdir, tlib2)
@@ -182,14 +191,8 @@ local netw_def = {
 local liquid_def = {
 	capa = CAPACITY,
 	peek = liquid.srv_peek,
-	put = function(pos, indir, name, amount)
-		local leftover = liquid.srv_put(pos, indir, name, amount)
-		if techage.is_activeformspec(pos) then
-			local nvm = techage.get_nvm(pos)
-			M(pos):set_string("formspec", formspec(State, pos, nvm))
-		end
-		return leftover
-	end,
+	put = put,
+	untake = put,
 	take = function(pos, indir, name, amount)
 		amount, name = liquid.srv_take(pos, indir, name, amount)
 		if techage.is_activeformspec(pos) then

--- a/lamps/growlight.lua
+++ b/lamps/growlight.lua
@@ -20,6 +20,7 @@ local Cable = techage.ElectricCable
 local power = techage.power
 local Flowers = {}
 local Plants = {}
+local Ignore = { ["flowers:waterlily_waving"] = true }
 -- 9 plant positions below the light
 local Positions = { 
 	{x = 0, y =-1, z = 0},
@@ -143,7 +144,9 @@ minetest.after(1, function()
 		if name and type(name) == "string" then
 			local mod = string.split(name, ":")[1]
 			if mod == "flowers" or mod == "bakedclay" then -- Bakedclay also registers flowers as decoration.
-				techage.register_flower(name)
+				if not Ignore[name] then
+					techage.register_flower(name)
+				end
 			end
 		end
 	end
@@ -151,7 +154,9 @@ minetest.after(1, function()
 		if type(name) == "string" then
 			local mod = string.split(name, ":")[1]
 			if mod == "farming" and ndef.on_timer then -- probably a plant that still needs to grow
-				techage.register_plant(name)
+				if not Ignore[name] then
+					techage.register_plant(name)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Hi Joe,

2 suggestions for your excellent Techage modpack:

0. Electrolyzer: without untake method defined, hydrogen disappears from device output inventory when pumping into full tank.
1. Growlight: waterlily should not grow on soil because: a) it is water plant b) on soil it is transparent so for player it looks like empty space
