### PR TITLE
TA4 Terminal: Fix possible crash

### DIFF
--- a/lua_controller/terminal.lua
+++ b/lua_controller/terminal.lua
@@ -201,7 +201,7 @@ techage.register_node({"techage:ta4_terminal"}, {
 			output(pos, payload)
 			return true
 		elseif topic == "msg" then
-			output(pos, payload.src..": "..payload.text)
+			output(pos, tostring(payload.src)..": "..tostring(payload.text))
 			return true
 		end
 	end,


### PR DESCRIPTION
Otherwise, a Lua error would occur when the payload is malformed.