### PR TITLE
Allow to configure item ratios in distributor filters

### DIFF
--- a/doc/manual_DE.lua
+++ b/doc/manual_DE.lua
@@ -457,6 +457,8 @@ techage.manual_DE.aText = {
   "\n"..
   "Bitte beachte\\, dass die Verteilung ein probabilistischer Vorgang ist\\, d.h. die Verhältnisse werden nicht exakt\\, sondern nur langfristig eingehalten.\n"..
   "\n"..
+  "In den Filtern beträgt die maximale Stackgröße 12\\; insgesamt können höchstens 36 Items konfiguriert werden.\n"..
+  "\n"..
   "\n"..
   "\n",
   "Die Kieswaschanlage ist eine komplexere Maschine mit dem Ziel\\, Usmium Nuggets aus gesiebtem Kies auszuwaschen. Für den Aufbau wird ein TA2 Kiesspüler mit Achsenantrieb\\, ein Trichter\\, eine Kiste\\, sowie fließendes Wasser benötigt. \n"..

--- a/doc/manual_DE.lua
+++ b/doc/manual_DE.lua
@@ -453,6 +453,10 @@ techage.manual_DE.aText = {
   "\n"..
   "Der Verarbeitungsleistung eines TA2 Verteilers beträgt 4 Items alle 2 s\\, wobei der Verteiler dabei versucht\\, die 4 Items auf die offenen Ausgänge zu verteilen.\n"..
   "\n"..
+  "Wird dasselbe Item in einem Filter mehrfach hinterlegt\\, so beeinflusst dies das langfristige Verteilungsverhältnis entsprechend.\n"..
+  "\n"..
+  "Bitte beachte\\, dass die Verteilung ein probabilistischer Vorgang ist\\, d.h. die Verhältnisse werden nicht exakt\\, sondern nur langfristig eingehalten.\n"..
+  "\n"..
   "\n"..
   "\n",
   "Die Kieswaschanlage ist eine komplexere Maschine mit dem Ziel\\, Usmium Nuggets aus gesiebtem Kies auszuwaschen. Für den Aufbau wird ein TA2 Kiesspüler mit Achsenantrieb\\, ein Trichter\\, eine Kiste\\, sowie fließendes Wasser benötigt. \n"..
@@ -1056,15 +1060,7 @@ techage.manual_DE.aText = {
   "\n"..
   "\n"..
   "\n",
-  "Die Funktion des TA3 Verteilers entspricht der von TA2 mit einer weiteren Betriebart.\n"..
-  "\n"..
-  "*1:1 Bestückungsfunktion*\n"..
-  "\n"..
-  "Wird nur ein Ausgang aktiviert und mit mehreren Items konfiguriert\\, so kann die 1:1 Checkbox angeklickt werden. In diesem Falle werden nur Items gemäß der Filtereinstellung angenommen und in der Reihenfolge\\, wie die Items im Filter eingetragen sind\\, in definierte Positionen im Ziel-Inventar abgelegt. Damit kann weder das Inventar des Verteilers noch des Zielblocks volllaufen. Dies funktioniert für Autocrafter\\, Industrieofen und Elektronikfabrik.\n"..
-  "Mit dieser Betriebsart lassen sich andere Maschinen wie bspw. der Autocrafter exakt gemäß dem eingestellten Rezept bestücken. \n"..
-  "\n"..
-  "Dies funktioniert nur nur\\, wenn die Inventare des Verteilers und des Zielblocks zuvor frei sind.\n"..
-  "\n"..
+  "Die Funktion des TA3 Verteilers entspricht der von TA2.\n"..
   "Die Verarbeitungsleistung beträgt 12 Items alle 4 s.\n"..
   "\n"..
   "\n"..

--- a/doc/manual_EN.lua
+++ b/doc/manual_EN.lua
@@ -452,6 +452,10 @@ techage.manual_EN.aText = {
   "\n"..
   "The processing power of a TA2 distributor is 4 items every 2 s\\, whereby the distributor tries to distribute the 4 items to the open outputs.\n"..
   "\n"..
+  "If the same item is configured multiple times in one filter\\, the long term distribution ratio will be influenced accordingly.\n"..
+  "\n"..
+  "Please note that the distribution is a probabilistic process. This means that the distribution rations won't be matched exactly\\, but only in the long term.\n"..
+  "\n"..
   "\n"..
   "\n",
   "The gravel washer is a more complex machine with the goal of washing Usmium nuggets out of sieved gravel. A TA2 rinser with axis drive\\, a hopper\\, a chest and running water are required for the installation.\n"..
@@ -1041,7 +1045,7 @@ techage.manual_EN.aText = {
   "\n"..
   "\n"..
   "\n",
-  "The function of the TA3 distributor corresponds to that of TA2 with another operating mode.\n"..
+  "The function of the TA3 distributor corresponds to that of TA2.\n"..
   "The processing power is 12 items every 4 s.\n"..
   "\n"..
   "\n"..

--- a/doc/manual_EN.lua
+++ b/doc/manual_EN.lua
@@ -456,6 +456,8 @@ techage.manual_EN.aText = {
   "\n"..
   "Please note that the distribution is a probabilistic process. This means that the distribution rations won't be matched exactly\\, but only in the long term.\n"..
   "\n"..
+  "The maximum stack size in the filters is 12\\; in total\\, not more than 36 items can be configured.\n"..
+  "\n"..
   "\n"..
   "\n",
   "The gravel washer is a more complex machine with the goal of washing Usmium nuggets out of sieved gravel. A TA2 rinser with axis drive\\, a hopper\\, a chest and running water are required for the installation.\n"..

--- a/manuals/manual_ta2_DE.md
+++ b/manuals/manual_ta2_DE.md
@@ -136,6 +136,8 @@ Wird dasselbe Item in einem Filter mehrfach hinterlegt, so beeinflusst dies das 
 
 Bitte beachte, dass die Verteilung ein probabilistischer Vorgang ist, d.h. die Verhältnisse werden nicht exakt, sondern nur langfristig eingehalten.
 
+In den Filtern beträgt die maximale Stackgröße 12; insgesamt können höchstens 36 Items konfiguriert werden.
+
 [ta2_distributor|image]
 
 

--- a/manuals/manual_ta2_DE.md
+++ b/manuals/manual_ta2_DE.md
@@ -132,6 +132,10 @@ Einstellbar ist die Betriebsart über die "blockiere" Checkbox.
 
 Der Verarbeitungsleistung eines TA2 Verteilers beträgt 4 Items alle 2 s, wobei der Verteiler dabei versucht, die 4 Items auf die offenen Ausgänge zu verteilen.
 
+Wird dasselbe Item in einem Filter mehrfach hinterlegt, so beeinflusst dies das langfristige Verteilungsverhältnis entsprechend.
+
+Bitte beachte, dass die Verteilung ein probabilistischer Vorgang ist, d.h. die Verhältnisse werden nicht exakt, sondern nur langfristig eingehalten.
+
 [ta2_distributor|image]
 
 

--- a/manuals/manual_ta2_EN.md
+++ b/manuals/manual_ta2_EN.md
@@ -137,6 +137,8 @@ If the same item is configured multiple times in one filter, the long term distr
 
 Please note that the distribution is a probabilistic process. This means that the distribution rations won't be matched exactly, but only in the long term.
 
+The maximum stack size in the filters is 12; in total, not more than 36 items can be configured.
+
 [ta2_distributor|image]
 
 

--- a/manuals/manual_ta2_EN.md
+++ b/manuals/manual_ta2_EN.md
@@ -133,6 +133,10 @@ The operating mode can be set using the "blocking mode" checkbox.
 
 The processing power of a TA2 distributor is 4 items every 2 s, whereby the distributor tries to distribute the 4 items to the open outputs.
 
+If the same item is configured multiple times in one filter, the long term distribution ratio will be influenced accordingly.
+
+Please note that the distribution is a probabilistic process. This means that the distribution rations won't be matched exactly, but only in the long term.
+
 [ta2_distributor|image]
 
 

--- a/manuals/manual_ta3_DE.md
+++ b/manuals/manual_ta3_DE.md
@@ -726,15 +726,7 @@ Die Verarbeitungsleistung beträgt 6 Items alle 2 s.
 
 ### TA3 Verteiler / Distributor
 
-Die Funktion des TA3 Verteilers entspricht der von TA2 mit einer weiteren Betriebart.
-
-**1:1 Bestückungsfunktion**
-
-Wird nur ein Ausgang aktiviert und mit mehreren Items konfiguriert, so kann die 1:1 Checkbox angeklickt werden. In diesem Falle werden nur Items gemäß der Filtereinstellung angenommen und in der Reihenfolge, wie die Items im Filter eingetragen sind, in definierte Positionen im Ziel-Inventar abgelegt. Damit kann weder das Inventar des Verteilers noch des Zielblocks volllaufen. Dies funktioniert für Autocrafter, Industrieofen und Elektronikfabrik.
-Mit dieser Betriebsart lassen sich andere Maschinen wie bspw. der Autocrafter exakt gemäß dem eingestellten Rezept bestücken. 
-
-Dies funktioniert nur nur, wenn die Inventare des Verteilers und des Zielblocks zuvor frei sind.
-
+Die Funktion des TA3 Verteilers entspricht der von TA2.
 Die Verarbeitungsleistung beträgt 12 Items alle 4 s.
 
 [ta3_distributor|image]

--- a/manuals/manual_ta3_EN.md
+++ b/manuals/manual_ta3_EN.md
@@ -709,7 +709,7 @@ The processing power is 6 items every 2 s.
 
 ### TA3 Distributor
 
-The function of the TA3 distributor corresponds to that of TA2 with another operating mode.
+The function of the TA3 distributor corresponds to that of TA2.
 The processing power is 12 items every 4 s.
 
 [ta3_distributor|image]


### PR DESCRIPTION
It allows to control the ratio in which certain items will use the different outputs.
This is done by adding an item multiple times to the same filter.

Because of this, the hardcoded permutations are replaced with a Fisher-Yates-Shuffle.
This is theoretically a little bit slower; but according to my measurements, about one million of copy-shuffle operations can be executed per second (tested with a table length of four); so it doesn't seem to be a big problem.

Additionally, a bit of outdated information was removed from the manuals.