### PR TITLE
Two contributions to excellent Techage

### DIFF
--- a/basic_machines/grinder.lua
+++ b/basic_machines/grinder.lua
@@ -99,7 +99,7 @@ local function src_to_dst(src_stack, idx, src_name, num_items, inp_num, inv, dst
 end
 			
 local function grinding(pos, crd, nvm, inv)
-	local num_items = 0
+	local blocked = false 	-- idle
 	for idx,stack in ipairs(inv:get_list("src")) do
 		if not stack:is_empty() then
 			local name = stack:get_name()
@@ -107,16 +107,21 @@ local function grinding(pos, crd, nvm, inv)
 				local recipe = Recipes[name]
 				if src_to_dst(stack, idx, name, crd.num_items, recipe.inp_num, inv, recipe.output) then
 					crd.State:keep_running(pos, nvm, COUNTDOWN_TICKS)
+					return
 				else
-					crd.State:blocked(pos, nvm)
+					blocked = true
 				end
 			else
 				crd.State:fault(pos, nvm)
+				return
 			end
-			return
 		end
 	end
-	crd.State:idle(pos, nvm)
+	if blocked then
+		crd.State:blocked(pos, nvm)
+	else
+		crd.State:idle(pos, nvm)
+	end
 end
 
 local function keep_running(pos, elapsed)

--- a/ta3_power/tiny_generator.lua
+++ b/ta3_power/tiny_generator.lua
@@ -203,11 +203,32 @@ minetest.register_node("techage:tiny_generator", {
 	on_rotate = screwdriver.disallow,
 	is_ground_content = false,
 
-	after_place_node = function(pos)
+	after_place_node = function(pos, placer, itemstack)
 		local nvm = techage.get_nvm(pos)
 		local number = techage.add_node(pos, "techage:tiny_generator")
 		nvm.running = false
 		nvm.burn_cycles = 0
+		if itemstack then
+			local stack_meta = itemstack:get_meta()
+			if stack_meta then
+				local liquid_name = stack_meta:get_string("liquid_name")
+				local liquid_amount = stack_meta:get_int("liquid_amount")
+				if liquid_name ~= "" and fuel.burntime(liquid.name) and
+				   liquid_amount >= 0 and liquid_amount <= fuel.CAPACITY then
+					nvm.liquid = nvm.liquid or {}
+					nvm.liquid.name = liquid_name
+					nvm.liquid.amount = liquid_amount
+				end
+				local burn_cycles = stack_meta:get_string("burn_cycles")
+				if burn_cycles ~= "" then
+					nvm.burn_cycles = tonumber(burn_cycles)
+				end
+				local burn_cycles_total = stack_meta:get_string("burn_cycles_total")
+				if burn_cycles_total ~= "" then
+					nvm.burn_cycles_total = tonumber(burn_cycles_total)
+				end
+			end
+		end
 		State:node_init(pos, nvm, number)
 		M(pos):set_string("formspec", formspec(State, pos, nvm))
 		M(pos):set_int("outdir", networks.side_to_outdir(pos, "R"))
@@ -221,11 +242,30 @@ minetest.register_node("techage:tiny_generator", {
 		techage.del_mem(pos)
 	end,
 
+	preserve_metadata = function(pos, oldnode, oldmetadata, drops)
+		local nvm = techage.get_nvm(pos)
+		if (nvm.liquid and nvm.liquid.name) or nvm.burn_cycles > 0 then
+			local meta = drops[1]:get_meta()
+			if nvm.liquid and nvm.liquid.name and nvm.liquid.amount > 0 then
+				-- generator tank is not empty
+				meta:set_string("liquid_name", nvm.liquid.name)
+				meta:set_int("liquid_amount", nvm.liquid.amount)
+			end
+			local fuel_text = "fuel: " .. tostring(nvm.liquid and nvm.liquid.amount or 0) .. "/" .. tostring(fuel.CAPACITY)
+			meta:set_string("burn_cycles", tostring(nvm.burn_cycles))
+			local cycles_text = "cycles: " .. tostring(nvm.burn_cycles)
+			if nvm.burn_cycles_total then
+				meta:set_string("burn_cycles_total", tostring(nvm.burn_cycles_total))
+				cycles_text = cycles_text .. "/" .. tostring(nvm.burn_cycles_total)
+			end
+			meta:set_string("description", S("TA3 Tiny Power Generator") .. " (" .. fuel_text .. ", " .. cycles_text .. ")")
+		end
+        end,
+
 	on_receive_fields = on_receive_fields,
 	on_rightclick = on_rightclick,
 	on_punch = fuel.on_punch,
 	on_timer = node_timer,
-	can_dig = fuel.can_dig,
 	liquid = liquid_def,
 	networks = net_def,
 })


### PR DESCRIPTION
Hello Joe,

Take it or reject it, you decide :-)

One patch allows to pick up tiny generator with fuel and burn cycles preserved. Since now minetest supports storing custom metadata when digging up items, I came to an idea that TinyGen should become more flexible when carried from place to place.
In general I support using barrels and canisters for more stationary machines, however this portable device can benefit from being carried with fuel - especially unloading before collecting is painful, as it usually involves emptying it using barrels and canisters. IMHO such portable generators should be allowed to  travel with fuel inside, as in real life. 

The other one provides small improvement for selecting recipes for Grinder. Recent addition of seed recipes with multiple input items made Grinder to block IMHO prematurely. Example: having 5 oat seeds in first slot and 6 wheat in second slot blocks device, while most players expect to have the latter 6 ones to be processed to flour. In general, it does not block grinder too early, making it traverse through whole inventory processing items if possible and block only if nothing more can be processed. I find it more logical, hope you too. Again, problem did not exist before multi-input seed recipes so maybe you are working on another approach to the algorithm ...   

Cheers
Micu