### PR TITLE
Allow to pause the sequencer with a TechAge command

### DIFF
--- a/logic/sequencer.lua
+++ b/logic/sequencer.lua
@@ -268,6 +268,8 @@ techage.register_node({"techage:ta3_sequencer"}, {
 			else
 				nvm.endless = false
 			end
+		elseif topic == "pause" then
+			stop_the_sequencer(pos)
 		else
 			return "unsupported"
 		end


### PR DESCRIPTION
Has the same effect as turning the sequencer off by hand.

Use case: You use a sequencer in combination with a TA Signal Lamp to build a flashing warning light.
You then want to turn this warning light on and off with a TechAge command.
Using the "off" command would result in unsetting the "Run endless" checkbox.