### PR TITLE
Add a .luacheckrc and fix warnings detected by luacheck

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,54 @@
+-- Specify the global variables
+read_globals = {
+	-- Defined by Minetest
+	"vector", "PseudoRandom", "PcgRandom", "VoxelArea", "dump", "ItemStack",
+	"string", "table",
+	minetest = {
+		fields = {
+			is_protected = {read_only = false},
+			get_translated_string = {read_only = false},
+		},
+		other_fields = true
+	},
+
+	-- Defined by minetest_game mods
+	"creative", "doors", "screwdriver", "stairs",
+	bucket = {
+		fields = {
+			liquids = {read_only = false, other_fields=true}
+		},
+		other_fields = true
+	},
+	default = {
+		fields = {
+			cool_lava = {read_only = false}
+		},
+		other_fields = true
+	},
+
+	-- Defined by other mods
+	"craftguide", "hyperloop", "i3", "lcdlib", "mesecon", "minecart",
+	"networks", "safer_lua", "stairsplus", "tubelib2", "unifieddyes",
+	"unified_inventory",
+	minecart = {
+		fields = {
+			tEntityNames = {read_only = false, other_fields=true}
+		},
+		other_fields = true
+	},
+}
+globals = {"techage"}
+
+-- Specify which warnings to ignore
+ignore = {
+	-- Style-related warnings, e.g. unused arguments and trailing whitespace
+	"212", "213", "411", "421", "422", "431", "432", "542",
+	"611", "612", "613", "614", "631",
+
+	-- Warnings which are mostly caused by unclean code but may reveal
+	-- accidental programming mistakes, e.g. unused variables
+	"211",
+}
+
+-- Skip files with unfinished code
+exclude_files = {"collider/terminal.lua"}

--- a/basic_machines/consumer.lua
+++ b/basic_machines/consumer.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Consumer node basis functionality.
 	It handles:
 	- up to 3 stages of nodes (TA2/TA3/TA4)
@@ -19,8 +19,6 @@
 ]]--
 
 -- for lazy programmers
-local S = function(pos) if pos then return minetest.pos_to_string(pos) end end
-local P = minetest.string_to_pos
 local M = minetest.get_meta
 
 -- Consumer Related Data
@@ -29,7 +27,6 @@ local CRDN = function(node) return (minetest.registered_nodes[node.name] or {}).
 
 local Tube = techage.Tube
 local power = networks.power
-local liquid = networks.liquid
 local CYCLE_TIME = 2
 
 local function get_keys(tbl)
@@ -54,7 +51,7 @@ end
 local function node_timer_pas(pos, elapsed)
 	local crd = CRD(pos)
 	local nvm = techage.get_nvm(pos)
-	
+
 	-- handle power consumption
 	if crd.power_netw and techage.needs_power(nvm) then
 		local consumed = power.consume_power(pos, crd.power_netw, nil, crd.power_consumption)
@@ -62,7 +59,7 @@ local function node_timer_pas(pos, elapsed)
 			crd.State:start(pos, nvm)
 		end
 	end
-	
+
 		-- call the node timer routine
 	if techage.is_operational(nvm) then
 		nvm.node_timer_call_cyle = (nvm.node_timer_call_cyle or 0) + 1
@@ -77,7 +74,7 @@ end
 local function node_timer_act(pos, elapsed)
 	local crd = CRD(pos)
 	local nvm = techage.get_nvm(pos)
-	
+
 	-- handle power consumption
 	if crd.power_netw and techage.needs_power(nvm) then
 		local consumed = power.consume_power(pos, crd.power_netw, nil, crd.power_consumption)
@@ -85,7 +82,7 @@ local function node_timer_act(pos, elapsed)
 			crd.State:nopower(pos, nvm)
 		end
 	end
-	
+
 	-- call the node timer routine
 	if techage.is_operational(nvm) then
 		nvm.node_timer_call_cyle = (nvm.node_timer_call_cyle or 0) + 1
@@ -111,7 +108,7 @@ local function prepare_tiles(tiles, stage, power_png)
 	return tbl
 end
 
--- 'validStates' is optional and can be used to e.g. enable 
+-- 'validStates' is optional and can be used to e.g. enable
 -- only one TA2 node {false, true, false, false}
 function techage.register_consumer(base_name, inv_name, tiles, tNode, validStates, node_name_prefix)
 	local names = {}
@@ -163,7 +160,7 @@ function techage.register_consumer(base_name, inv_name, tiles, tNode, validState
 				State = tState,
 				-- number of items to be processed per cycle
 				num_items = tNode.num_items and tNode.num_items[stage],
-				power_consumption = power_used and 
+				power_consumption = power_used and
 				tNode.power_consumption[stage] or 0,
 				node_timer = tNode.node_timer,
 				cycle_time = tNode.cycle_time,
@@ -204,7 +201,7 @@ function techage.register_consumer(base_name, inv_name, tiles, tNode, validState
 				techage.remove_node(pos, oldnode, oldmetadata)
 				techage.del_mem(pos)
 			end
-			
+
 			tNode.groups.not_in_creative_inventory = 0
 
 			local def_pas = {
@@ -285,14 +282,14 @@ function techage.register_consumer(base_name, inv_name, tiles, tNode, validState
 					def_act[k] = v
 				end
 			end
-			
+
 			minetest.register_node(name_act, def_act)
 
 			if power_used then
 				power.register_nodes({name_pas, name_act}, power_network, "con", sides)
 			end
 			techage.register_node({name_pas, name_act}, tNode.tubing)
-			
+
 			if tNode.tube_sides then
 				Tube:set_valid_sides(name_pas, get_keys(tNode.tube_sides))
 				Tube:set_valid_sides(name_act, get_keys(tNode.tube_sides))

--- a/basic_machines/distributor.lua
+++ b/basic_machines/distributor.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	TA2/TA3/TA4 Distributor
-	
+
 ]]--
 
 -- for lazy programmers
@@ -34,7 +34,7 @@ local INFO = [[Turn port on/off or read its state: command = 'port', payload = r
 
 --local Side2Color = {B="red", L="green", F="blue", R="yellow"}
 local SlotColors = {"red", "green", "blue", "yellow"}
-local Num2Ascii = {"B", "L", "F", "R"} 
+local Num2Ascii = {"B", "L", "F", "R"}
 local FilterCache = {} -- local cache for filter settings
 
 local function filter_settings(pos)
@@ -72,9 +72,9 @@ local function filter_settings(pos)
 			end
 		end
 	end
-	
+
 	FilterCache[minetest.hash_node_position(pos)] = {
-		ItemFilter = ItemFilter, 
+		ItemFilter = ItemFilter,
 		OpenPorts = OpenPorts,
 	}
 end
@@ -88,7 +88,7 @@ local function get_filter_settings(pos)
 --	}
 --	local OpenPorts = {3}
 --	return ItemFilter, OpenPorts
-	
+
 	local hash = minetest.hash_node_position(pos)
 	if FilterCache[hash] == nil then
 		filter_settings(pos)
@@ -111,8 +111,8 @@ local function blocking_checkbox(pos, filter, is_hp)
 		M(pos):set_int("blocking", 0) -- disable blocking
 	end
 	return ""
-end		
-		
+end
+
 local function formspec(self, pos, nvm)
 	local filter = minetest.deserialize(M(pos):get_string("filter")) or {false,false,false,false}
 	local is_hp = nvm.high_performance == true
@@ -185,20 +185,18 @@ end
 local function allow_metadata_inventory_put(pos, listname, index, stack, player)
 	local inv = M(pos):get_inventory()
 	local list = inv:get_list(listname)
-	
+
 	if minetest.is_protected(pos, player:get_player_name()) then
 		return 0
 	end
 	if listname == "src" then
 		CRD(pos).State:start_if_standby(pos)
 		return stack:get_count()
-	else
-		stack:add_item(list[index])
-		local max_items_to_limit = FILTER_ITEM_LIMIT - get_total_filter_items_number(pos, listname, index)
-		stack:set_count(math.min(FILTER_ITEM_LIMIT_PER_STACK, stack:get_count(), max_items_to_limit))
-		inv:set_stack(listname, index, stack)
-		return 0
 	end
+	stack:add_item(list[index])
+	local max_items_to_limit = FILTER_ITEM_LIMIT - get_total_filter_items_number(pos, listname, index)
+	stack:set_count(math.min(FILTER_ITEM_LIMIT_PER_STACK, stack:get_count(), max_items_to_limit))
+	inv:set_stack(listname, index, stack)
 	return 0
 end
 
@@ -247,7 +245,7 @@ local function tubelib2_on_update2(pos, outdir, tlib2, node)
 			is_ta4_tube = is_ta4_tube and techage.TA4tubes[node.name]
 		end
 	end
-	
+
 	local nvm = techage.get_nvm(pos)
 	local crd = CRD(pos)
 	if CRD(pos).stage == 4 and not is_ta4_tube then
@@ -293,12 +291,11 @@ end
 local function distributing(pos, inv, crd, nvm)
 	local item_filter, open_ports = get_filter_settings(pos)
 	local sum_num_pushed = 0
-	local num_pushed = 0
 	local blocking_mode = M(pos):get_int("blocking") == 1
-	
+
 	-- start searching after last position
 	local offs = nvm.last_index or 1
-	
+
 	for i = 1, SRC_INV_SIZE do
 		local idx = ((i + offs - 1) % 8) + 1
 		local stack = inv:get_stack("src", idx)
@@ -307,8 +304,8 @@ local function distributing(pos, inv, crd, nvm)
 		local num_to_push = math.min((nvm.num_items or crd.num_items) - sum_num_pushed, num_items)
 		local stack_to_push = stack:peek_item(num_to_push)
 		local filter = item_filter[item_name]
-		num_pushed = 0
-		
+		local num_pushed = 0
+
 		if filter and #filter > 0 then
 			-- Push items based on filter
 			num_pushed = push_item(pos, filter, stack_to_push, num_to_push, nvm)
@@ -320,16 +317,16 @@ local function distributing(pos, inv, crd, nvm)
 			-- Push items based on open ports
 			num_pushed = push_item(pos, open_ports, stack_to_push, num_to_push, nvm)
 		end
-			
+
 		sum_num_pushed = sum_num_pushed + num_pushed
 		stack:take_item(num_pushed)
 		inv:set_stack("src", idx, stack)
-		if sum_num_pushed >= (nvm.num_items or crd.num_items) then 
+		if sum_num_pushed >= (nvm.num_items or crd.num_items) then
 			nvm.last_index = idx
-			break 
+			break
 		end
 	end
-	
+
 	if sum_num_pushed == 0 then
 		crd.State:blocked(pos, nvm)
 	else
@@ -370,9 +367,9 @@ local function on_receive_fields(pos, formname, fields, player)
 		meta:set_int("blocking", fields.blocking == "true" and 1 or 0)
 	end
 	meta:set_string("filter", minetest.serialize(filter))
-	
+
 	filter_settings(pos)
-	
+
 	local nvm = techage.get_nvm(pos)
 	if fields.state_button ~= nil then
 		crd.State:state_button_event(pos, nvm, fields)
@@ -391,9 +388,9 @@ local function change_filter_settings(pos, slot, val)
 		filter[num] = val == "on"
 	end
 	meta:set_string("filter", minetest.serialize(filter))
-	
+
 	filter_settings(pos)
-	
+
 	local nvm = techage.get_nvm(pos)
 	meta:set_string("formspec", formspec(CRD(pos).State, pos, nvm))
 	return true
@@ -474,7 +471,7 @@ local tubing = {
 			else
 				return change_filter_settings(pos, slot, val)
 			end
-		else		
+		else
 			return CRD(pos).State:on_receive_message(pos, topic, payload)
 		end
 	end,

--- a/basic_machines/forceload.lua
+++ b/basic_machines/forceload.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	Forceload block
-	
+
 ]]--
 
 -- for lazy programmers
@@ -38,7 +38,7 @@ end
 local function remove_list_elem(list, x)
 	local n = nil
 	for idx, v in ipairs(list) do
-		if vector.equals(v, x) then 
+		if vector.equals(v, x) then
 			n = idx
 			break
 		end
@@ -59,12 +59,12 @@ local function postload_area(pos)
 		minetest.after(60, postload_area, pos)
 	end
 end
-	
+
 local function add_pos(pos, player)
 	local meta = player:get_meta()
 	local lPos = minetest.deserialize(meta:get_string("techage_forceload_blocks")) or {}
 	if not in_list(lPos, pos) and (#lPos < techage.max_num_forceload_blocks or
-				creative and creative.is_enabled_for and 
+				minetest.global_exists("creative") and
 				creative.is_enabled_for(player:get_player_name())) then
 		lPos[#lPos+1] = pos
 		local meta = player:get_meta()
@@ -73,7 +73,7 @@ local function add_pos(pos, player)
 	end
 	return false
 end
-	
+
 local function del_pos(pos, player)
 	local meta = player:get_meta()
 	local lPos = minetest.deserialize(meta:get_string("techage_forceload_blocks")) or {}
@@ -116,7 +116,6 @@ local function formspec(name)
 		local tRes = {}
 		for idx,pos in ipairs(lPos) do
 			local pos1, pos2 = calc_area(pos)
-			local ypos = 0.2 + idx * 0.4
 			tRes[#tRes+1] = idx
 			tRes[#tRes+1] = minetest.formspec_escape(P2S(pos1))
 			tRes[#tRes+1] = "to"
@@ -202,10 +201,10 @@ minetest.register_node("techage:forceload", {
 	after_dig_node = after_dig_node,
 	on_rightclick = on_rightclick,
 	on_punch = on_punch,
-	
+
 	paramtype = "light",
 	sunlight_propagates = true,
-	groups = {choppy=2, cracky=2, crumbly=2, 
+	groups = {choppy=2, cracky=2, crumbly=2,
 		digtron_protected = 1,
 		not_in_creative_inventory = techage.max_num_forceload_blocks == 0 and 1 or 0},
 	is_ground_content = false,
@@ -236,17 +235,17 @@ minetest.register_node("techage:forceloadtile", {
 			{-4/16,  -8/16, -4/16, 4/16,  -15/32,  4/16},
 		},
 	},
-	
+
 	on_place = on_place,
 	after_place_node = after_place_node,
 	after_dig_node = after_dig_node,
 	on_rightclick = on_rightclick,
 	on_punch = on_punch,
-	
+
 	paramtype = "light",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
-	groups = {choppy=2, cracky=2, crumbly=2, 
+	groups = {choppy=2, cracky=2, crumbly=2,
 		not_in_creative_inventory = techage.max_num_forceload_blocks == 0 and 1 or 0},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),

--- a/basic_machines/itemsource.lua
+++ b/basic_machines/itemsource.lua
@@ -7,16 +7,15 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Item Source Block
 ]]--
 
 -- for lazy programmers
 local M = minetest.get_meta
-local S = techage.S
 
 local CYCLE_TIME = 30
-	
+
 local function formspec()
 	return "size[8,7.2]"..
 		default.gui_bg..
@@ -32,7 +31,7 @@ local function allow_metadata_inventory_put(pos, listname, index, stack, player)
 	if minetest.is_protected(pos, player:get_player_name()) then
 		return 0
 	end
-	
+
 	return stack:get_count()
 end
 
@@ -40,7 +39,7 @@ local function allow_metadata_inventory_take(pos, listname, index, stack, player
 	if minetest.is_protected(pos, player:get_player_name()) then
 		return 0
 	end
-	
+
 	return stack:get_count()
 end
 
@@ -81,7 +80,7 @@ minetest.register_node("techage:itemsource", {
 		end
 		return true
 	end,
-	
+
 	allow_metadata_inventory_put = allow_metadata_inventory_put,
 	allow_metadata_inventory_take = allow_metadata_inventory_take,
 
@@ -97,4 +96,4 @@ techage.register_node({"techage:itemsource"}, {
 	on_node_load = function(pos)
 		minetest.get_node_timer(pos):start(CYCLE_TIME)
 	end,
-})		
+})

--- a/basic_machines/quarry.lua
+++ b/basic_machines/quarry.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Quarry machine to dig stones and other ground blocks.
-	
+
 	The Quarry digs a hole (default) 5x5 blocks large and up to 80 blocks deep.
 	It starts at the given level (0 is same level as the quarry block,
 	1 is one level higher and so on)) and goes down to the given depth number.
@@ -18,8 +18,6 @@
 ]]--
 
 -- for lazy programmers
-local P2S = function(pos) if pos then return minetest.pos_to_string(pos) end end
-local S2P = minetest.string_to_pos
 local M = minetest.get_meta
 -- Consumer Related Data
 local CRD = function(pos) return (minetest.registered_nodes[techage.get_node_lvm(pos).name] or {}).consumer end
@@ -34,7 +32,7 @@ local Side2Facedir = {F=0, R=1, B=2, L=3, D=4, U=5}
 local Depth2Idx = {[1]=1 ,[2]=2, [3]=3, [5]=4, [10]=5, [15]=6, [20]=7, [25]=8, [40]=9, [60]=10, [80]=11}
 local Holesize2Idx = {["3x3"] = 1, ["5x5"] = 2, ["7x7"] = 3, ["9x9"] = 4, ["11x11"] = 5}
 local Holesize2Diameter = {["3x3"] = 3, ["5x5"] = 5, ["7x7"] = 7, ["9x9"] = 9, ["11x11"] = 11}
-local Level2Idx = {[2]=1, [1]=2, [0]=3, [-1]=4, [-2]=5, [-3]=6, 
+local Level2Idx = {[2]=1, [1]=2, [0]=3, [-1]=4, [-2]=5, [-3]=6,
 				   [-5]=7, [-10]=8, [-15]=9, [-20]=10}
 
 local function formspec(self, pos, nvm)
@@ -53,7 +51,7 @@ local function formspec(self, pos, nvm)
 	elseif CRD(pos).stage == 2 then
 		depth_list = "1,2,3,5,10,15,20"
 	end
-	
+
 	return "size[8,8]"..
 		default.gui_bg..
 		default.gui_bg_img..
@@ -61,11 +59,11 @@ local function formspec(self, pos, nvm)
 		"box[0,-0.1;7.8,0.5;#c6e8ff]"..
 		"label[3.5,-0.1;"..minetest.colorize( "#000000", S("Quarry")).."]"..
 		techage.question_mark_help(8, tooltip)..
-		"dropdown[0,0.8;1.5;level;2,1,0,-1,-2,-3,-5,-10,-15,-20;"..level_idx.."]".. 
+		"dropdown[0,0.8;1.5;level;2,1,0,-1,-2,-3,-5,-10,-15,-20;"..level_idx.."]"..
 		"label[1.6,0.9;"..S("Start level").."]"..
-		"dropdown[0,1.8;1.5;depth;"..depth_list..";"..depth_idx.."]".. 
+		"dropdown[0,1.8;1.5;depth;"..depth_list..";"..depth_idx.."]"..
 		"label[1.6,1.9;"..S("Digging depth").." ("..level..")]"..
-		"dropdown[0,2.8;1.5;hole_size;"..hsize_list..";"..hsize_idx.."]".. 
+		"dropdown[0,2.8;1.5;hole_size;"..hsize_list..";"..hsize_idx.."]"..
 		"label[1.6,2.9;"..S("Hole size").."]"..
 		"list[context;main;5,0.8;3,3;]"..
 		"image[4,0.8;1,1;"..techage.get_power_image(pos, nvm).."]"..
@@ -80,7 +78,7 @@ local function play_sound(pos)
 	local mem = techage.get_mem(pos)
 	if not mem.handle or mem.handle == -1 then
 		mem.handle = minetest.sound_play("techage_quarry", {
-			pos = pos, 
+			pos = pos,
 			gain = 1.5,
 			max_hear_distance = 15,
 			loop = true})
@@ -114,7 +112,7 @@ local function get_pos(pos, facedir, side, steps)
 	facedir = (facedir + Side2Facedir[side]) % 4
 	local dir = vector.multiply(minetest.facedir_to_dir(facedir), steps or 1)
 	return vector.add(pos, dir)
-end	
+end
 
 local function allow_metadata_inventory_put(pos, listname, index, stack, player)
 	if minetest.is_protected(pos, player:get_player_name()) then
@@ -147,7 +145,7 @@ local function get_corner_positions(pos, facedir, hole_diameter)
 	return pos1, pos2
 end
 
-local function is_air_level(pos1, pos2, hole_diameter) 
+local function is_air_level(pos1, pos2, hole_diameter)
 	return #minetest.find_nodes_in_area(pos1, pos2, {"air"}) == hole_diameter * hole_diameter
 end
 
@@ -189,7 +187,7 @@ local function quarry_task(pos, crd, nvm)
 		end
 		return at_least_one_added
 	end
-	
+
 	local pos1, pos2 = get_corner_positions(pos, facedir, nvm.hole_diameter)
 	nvm.level = 1
 	for y_curr = y_first, y_last, -1 do
@@ -197,16 +195,16 @@ local function quarry_task(pos, crd, nvm)
 		pos2.y = y_curr
 
 		nvm.level = y_first - y_curr
-		
+
 		if minetest.is_area_protected(pos1, pos2, owner, 5) then
 			crd.State:fault(pos, nvm, S("area is protected"))
 			return
 		end
-		
+
 		if not is_air_level(pos1, pos2, nvm.hole_diameter) then
 			mark_area(pos1, pos2, owner)
 			coroutine.yield()
-			
+
 			for zoffs = 1, nvm.hole_diameter do
 				for xoffs = 1, nvm.hole_diameter do
 					local qpos = get_quarry_pos(pos1, xoffs, zoffs)
@@ -226,20 +224,20 @@ local function quarry_task(pos, crd, nvm)
 	end
 	crd.State:stop(pos, nvm, S("finished"))
 end
-	
+
 local function keep_running(pos, elapsed)
 	local mem = techage.get_mem(pos)
 	if not mem.co then
 		mem.co = coroutine.create(quarry_task)
 	end
-	
+
 	local nvm = techage.get_nvm(pos)
 	local crd = CRD(pos)
 	local _, err = coroutine.resume(mem.co, pos, crd, nvm)
 	if err then
 		minetest.log("error", "[TA4 Quarry Coroutine Error]" .. err)
 	end
-		
+
 	if techage.is_activeformspec(pos) then
 		M(pos):set_string("formspec", formspec(crd.State, pos, nvm))
 	end
@@ -268,7 +266,7 @@ local function on_receive_fields(pos, formname, fields, player)
 	end
 	local nvm = techage.get_nvm(pos)
 	local mem = techage.get_mem(pos)
-	
+
 	if fields.depth then
 		if tonumber(fields.depth) ~= nvm.quarry_depth then
 			nvm.quarry_depth = tonumber(fields.depth)
@@ -281,7 +279,7 @@ local function on_receive_fields(pos, formname, fields, player)
 			CRD(pos).State:stop(pos, nvm)
 		end
 	end
-	
+
 	if fields.level then
 		if tonumber(fields.level) ~= nvm.start_level then
 			nvm.start_level = tonumber(fields.level)
@@ -373,7 +371,7 @@ local tubing = {
 	end,
 }
 
-local node_name_ta2, node_name_ta3, node_name_ta4 = 
+local node_name_ta2, node_name_ta3, node_name_ta4 =
 	techage.register_consumer("quarry", S("Quarry"), tiles, {
 		drawtype = "normal",
 		cycle_time = CYCLE_TIME,

--- a/basis/fly_lib.lua
+++ b/basis/fly_lib.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	Block fly/move library
-	
+
 ]]--
 
 -- for lazy programmers
@@ -22,7 +22,7 @@ local flylib = {}
 
 local function lvect_add_vec(lvect1, offs)
 	if not lvect1 or not offs then return end
-	
+
 	local lvect2 = {}
 	for _, v in ipairs(lvect1) do
 		lvect2[#lvect2 + 1] = vector.add(v, offs)
@@ -32,7 +32,7 @@ end
 
 local function lvect_add(lvect1, lvect2)
 	if not lvect1 or not lvect2 then return end
-	
+
 	local lvect3 = {}
 	for i, v in ipairs(lvect1) do
 		lvect3[#lvect3 + 1] = vector.add(v, lvect2[i])
@@ -42,7 +42,7 @@ end
 
 local function lvect_subtract(lvect1, lvect2)
 	if not lvect1 or not lvect2 then return end
-	
+
 	local lvect3 = {}
 	for i, v in ipairs(lvect1) do
 		lvect3[#lvect3 + 1] = vector.subtract(v, lvect2[i])
@@ -58,7 +58,7 @@ local function rotate(v, yaw)
 end
 
 -------------------------------------------------------------------------------
--- to_path function for the fly/move path 
+-- to_path function for the fly/move path
 -------------------------------------------------------------------------------
 
 local function strsplit(text)
@@ -79,9 +79,9 @@ function flylib.to_vector(s)
 	local x,y,z = unpack(string.split(s, ","))
 	if x and y and z then
 		return {
-			x=tonumber(x) or 0, 
-			y=tonumber(y) or 0, 
-			z=tonumber(z) or 0, 
+			x=tonumber(x) or 0,
+			y=tonumber(y) or 0,
+			z=tonumber(z) or 0,
 		}
 	end
 end
@@ -89,7 +89,7 @@ end
 function flylib.to_path(s, max_dist)
 	local tPath
 	local dist = 0
-	
+
 	for _, line in ipairs(strsplit(s)) do
 		line = trim(line)
 		line = string.split(line, "--", true, 1)[1] or ""
@@ -125,7 +125,7 @@ local function reverse_path(lpath)
 	end
 	return lres
 end
-	
+
 local function dest_offset(lpath)
 	local offs = {x=0, y=0, z=0}
 	for i = 1,#lpath do
@@ -133,9 +133,9 @@ local function dest_offset(lpath)
 	end
 	return offs
 end
-	
+
 -------------------------------------------------------------------------------
--- Entity / Move / Attach / Detach 
+-- Entity / Move / Attach / Detach
 -------------------------------------------------------------------------------
 local MIN_SPEED = 0.4
 local MAX_SPEED = 8
@@ -167,7 +167,7 @@ end
 -- Check access conflicts with other mods
 local function lock_player(player)
 	local meta = player:get_meta()
-	if meta:get_int("player_physics_locked") == 0 then 
+	if meta:get_int("player_physics_locked") == 0 then
 		meta:set_int("player_physics_locked", 1)
 		meta:set_string("player_physics_locked_by", "ta_flylib")
 		return true
@@ -177,7 +177,7 @@ end
 
 local function unlock_player(player)
 	local meta = player:get_meta()
-	if meta:get_int("player_physics_locked") == 1 then 
+	if meta:get_int("player_physics_locked") == 1 then
 		if meta:get_string("player_physics_locked_by") == "ta_flylib" then
 			meta:set_int("player_physics_locked", 0)
 			meta:set_string("player_physics_locked_by", "")
@@ -294,7 +294,7 @@ local function entity_to_node(pos, obj)
 			nvm.running = nil
 		end
 		obj:remove()
-		
+
 		local node =  minetest.get_node(pos)
 		local ndef1 = minetest.registered_nodes[name]
 		local ndef2 = minetest.registered_nodes[node.name]
@@ -321,7 +321,7 @@ end
 local function node_to_entity(start_pos)
 	local meta = M(start_pos)
 	local node, metadata
-	
+
 	if meta:contains("ta_move_block") then
 		-- Move-block stored as metadata
 		node = minetest.deserialize(meta:get_string("ta_move_block"))
@@ -335,17 +335,17 @@ local function node_to_entity(start_pos)
 	end
 	local obj = minetest.add_entity(start_pos, "techage:move_item")
 	if obj then
-		local self = obj:get_luaentity() 
+		local self = obj:get_luaentity()
 		local rot = techage.facedir_to_rotation(node.param2)
 		obj:set_rotation(rot)
 		obj:set_properties({wield_item=node.name})
 		obj:set_armor_groups({immortal=1})
-		
+
 		-- To be able to revert to node
 		self.item_name = node.name
 		self.param2 = node.param2
 		self.metadata = metadata or {}
-		
+
 		-- Prepare for attachments
 		self.players = {}
 		self.entities = {}
@@ -412,7 +412,7 @@ local function handover_to(obj, self, pos1)
 				nvm.lpos1 = nvm.lpos1 or {}
 				if self.move2to1 then
 					nvm.lpos1[self.pos1_idx] = pos2
-					
+
 				else
 					nvm.lpos1[self.pos1_idx] = pos1
 				end
@@ -435,7 +435,7 @@ minetest.register_entity("techage:move_item", {
 		visual_size = {x=0.67, y=0.67, z=0.67},
 		selectionbox = {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
 	},
-	
+
 	get_staticdata = function(self)
 		return minetest.serialize({
 			item_name = self.item_name,
@@ -454,7 +454,7 @@ minetest.register_entity("techage:move_item", {
 			respawn = true,
 		})
 	end,
-	
+
 	on_activate = function(self, staticdata)
 		if staticdata then
 			local tbl = minetest.deserialize(staticdata) or {}
@@ -478,7 +478,7 @@ minetest.register_entity("techage:move_item", {
 			end
 		end
 	end,
-	
+
 	on_step = function(self, dtime, moveresult)
 		local stop_obj = function(obj, self)
 			local dest_pos = self.dest_pos
@@ -490,14 +490,14 @@ minetest.register_entity("techage:move_item", {
 			self.ttl = 2
 			return dest_pos
 		end
-		
+
 		if self.dest_pos then
 			local obj = self.object
 			local pos = obj:get_pos()
 			local dist = vector.distance(pos, self.dest_pos)
 			local speed = calc_speed(obj:get_velocity())
 			self.old_dist = self.old_dist or dist
-			
+
 			-- Landing
 			if self.lpath and self.lpath[self.path_idx] then
 				if dist < 1 or dist > self.old_dist then
@@ -520,26 +520,26 @@ minetest.register_entity("techage:move_item", {
 					return
 				end
 			end
-			
+
 			self.old_dist = dist
-			
-			-- Braking or limit max speed 
+
+			-- Braking or limit max speed
 			if self.handover then
 				if speed > (dist * 4) or speed > self.max_speed then
-					speed = math.min(speed, math.max(dist * 4, MIN_SPEED)) 
+					speed = math.min(speed, math.max(dist * 4, MIN_SPEED))
 					local vel = vector.multiply(self.dir,speed)
 					obj:set_velocity(vel)
 					obj:set_acceleration({x=0, y=0, z=0})
 				end
 			else
 				if speed > (dist * 2) or speed > self.max_speed then
-					speed = math.min(speed, math.max(dist * 2, MIN_SPEED)) 
+					speed = math.min(speed, math.max(dist * 2, MIN_SPEED))
 					local vel = vector.multiply(self.dir,speed)
 					obj:set_velocity(vel)
 					obj:set_acceleration({x=0, y=0, z=0})
 				end
 			end
-		
+
 		elseif self.ttl then
 			self.ttl = self.ttl - dtime
 			if self.ttl < 0 then
@@ -566,19 +566,19 @@ end
 local function is_simple_node(pos)
 	-- special handling
 	local name = minetest.get_node(pos).name
-	if SimpleNodes[name] ~= nil then 
-		return SimpleNodes[name] 
+	if SimpleNodes[name] ~= nil then
+		return SimpleNodes[name]
 	end
-	
+
 	local ndef = minetest.registered_nodes[name]
 	if not ndef or name == "air" or name == "ignore" then return false end
 	-- don't remove nodes with some intelligence or undiggable nodes
 	if ndef.drop == "" then return false end
 	if ndef.diggable == false then return false end
 	if ndef.after_dig_node then return false end
-	
+
 	return true
-end	
+end
 
 local function move_node(pos, pos1_idx, start_pos, lpath, max_speed, height, move2to1, handover, cpos)
 	local pos2 = next_path_pos(start_pos, lpath, 1)
@@ -618,7 +618,7 @@ local function move_nodes(pos, meta, nvm, lpath, max_speed, height, move2to1, ha
 	--print("move_nodes", dump(nvm), dump(lpath), max_speed, height, move2to1, handover)
 	local owner = meta:get_string("owner")
 	techage.counting_add(owner, #nvm.lpos1 * #lpath)
-	
+
 	for idx = 1, #nvm.lpos1 do
 		local pos1 = nvm.lpos1[idx]
 		local pos2 = nvm.lpos2[idx]
@@ -650,27 +650,29 @@ local function move_nodes(pos, meta, nvm, lpath, max_speed, height, move2to1, ha
 	return true
 end
 
-function flylib.move_to_other_pos(pos, move2to1)	
+function flylib.move_to_other_pos(pos, move2to1)
 	local meta = M(pos)
 	local nvm = techage.get_nvm(pos)
-	local lpath, err = flylib.to_path(meta:get_string("path")) or {}
+	local lpath, err = flylib.to_path(meta:get_string("path"))
+	if err then
+		return false
+	end
+	lpath = lpath or {}
 	local max_speed = meta:contains("max_speed") and meta:get_int("max_speed") or MAX_SPEED
 	local height = meta:contains("height") and meta:get_float("height") or 1
 	local handover
-	
-	if err then return false end
-	
+
 	height = techage.in_range(height, 0, 1)
 	max_speed = techage.in_range(max_speed, MIN_SPEED, MAX_SPEED)
 	nvm.lpos1 = nvm.lpos1 or {}
-	
+
 	local offs = dest_offset(lpath)
 	if move2to1 then
 		lpath = reverse_path(lpath)
 	end
 	-- calc destination positions
 	nvm.lpos2 = lvect_add_vec(nvm.lpos1, offs)
-	
+
 	if move2to1 then
 		handover = meta:contains("handoverA") and meta:get_string("handoverA")
 	else
@@ -688,9 +690,9 @@ function flylib.rotate_nodes(pos, posses1, rot)
 	local posses2 = techage.rotate_around_center(posses1, rot, cpos)
 	local param2
 	local nodes2 = {}
-	
+
 	techage.counting_add(owner, #posses1 * 2)
-	
+
 	for i, pos1 in ipairs(posses1) do
 		local node = techage.get_node_lvm(pos1)
 		if rot == "l" then

--- a/basis/lib.lua
+++ b/basis/lib.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Helper functions
 
 ]]--
@@ -69,8 +69,8 @@ local RotationViaYAxis = {}
 for _,row in ipairs(ROTATION) do
 	for i = 1,4 do
 		local val = row[i]
-		local left  = row[i == 1 and 4 or i - 1] 
-		local right = row[i == 4 and 1 or i + 1] 
+		local left  = row[i == 1 and 4 or i - 1]
+		local right = row[i == 4 and 1 or i + 1]
 		RotationViaYAxis[val] = {left, right}
 	end
 end
@@ -250,8 +250,8 @@ end
 
 -- returns true, if node can be dug, otherwise false
 function techage.can_node_dig(node, ndef)
-	if RegisteredNodesToBeDug[node.name] then 
-		return true 
+	if RegisteredNodesToBeDug[node.name] then
+		return true
 	end
 	if not ndef then return false end
 	if node.name == "ignore" then return false end
@@ -329,7 +329,7 @@ function techage.dropped_node(node, ndef)
 		return handle_drop(ndef.drop)
 	end
 	return ndef.drop or node.name
-end	
+end
 
 -- needed for windmill plants
 local function determine_ocean_ids()
@@ -363,7 +363,7 @@ function techage.item_image(x, y, itemname, count)
 	local tooltip = "tooltip["..x..","..y..";1,1;"..text..";#0C3D32;#FFFFFF]"
 
 	if minetest.registered_tools[name] and size > 1 then
-		local offs = 0
+		local offs
 		if size < 10 then
 			offs = 0.65
 		elseif size < 100 then
@@ -375,7 +375,7 @@ function techage.item_image(x, y, itemname, count)
 		end
 		label = "label["..(x + offs)..","..(y + 0.45)..";"..tostring(size).."]"
 	end
-	
+
 	return "box["..x..","..y..";0.85,0.9;#808080]"..
 		"item_image["..x..","..y..";1,1;"..itemname.."]"..
 		tooltip..
@@ -386,15 +386,69 @@ function techage.item_image_small(x, y, itemname, tooltip_prefix)
 	local name = unpack(string.split(itemname, " "))
 	local tooltip = ""
 	local ndef = minetest.registered_nodes[name] or minetest.registered_items[name] or minetest.registered_craftitems[name]
-	
+
 	if ndef and ndef.description then
 		local text = minetest.formspec_escape(ndef.description)
 		tooltip = "tooltip["..x..","..y..";0.8,0.8;"..tooltip_prefix..": "..text..";#0C3D32;#FFFFFF]"
 	end
-	
+
 	return "box["..x..","..y..";0.65,0.7;#808080]"..
 		"item_image["..x..","..y..";0.8,0.8;"..name.."]"..
 		tooltip
+end
+
+-- Copied from Minetest's builtin/common/misc_helpers.lua
+local function basic_dump(o)
+	local tp = type(o)
+	if tp == "number" then
+		return tostring(o)
+	elseif tp == "string" then
+		return string.format("%q", o)
+	elseif tp == "boolean" then
+		return tostring(o)
+	elseif tp == "nil" then
+		return "nil"
+	-- Uncomment for full function dumping support.
+	-- Not currently enabled because bytecode isn't very human-readable and
+	-- dump's output is intended for humans.
+	--elseif tp == "function" then
+	--	return string.format("loadstring(%q)", string.dump(o))
+	elseif tp == "userdata" then
+		return tostring(o)
+	else
+		return string.format("<%s>", tp)
+	end
+end
+
+local keywords = {
+	["and"] = true,
+	["break"] = true,
+	["do"] = true,
+	["else"] = true,
+	["elseif"] = true,
+	["end"] = true,
+	["false"] = true,
+	["for"] = true,
+	["function"] = true,
+	["goto"] = true,  -- Lua 5.2
+	["if"] = true,
+	["in"] = true,
+	["local"] = true,
+	["nil"] = true,
+	["not"] = true,
+	["or"] = true,
+	["repeat"] = true,
+	["return"] = true,
+	["then"] = true,
+	["true"] = true,
+	["until"] = true,
+	["while"] = true,
+}
+local function is_valid_identifier(str)
+	if not str:find("^[a-zA-Z_][a-zA-Z0-9_]*$") or keywords[str] then
+		return false
+	end
+	return true
 end
 
 function techage.mydump(o, indent, nested, level)
@@ -412,7 +466,7 @@ function techage.mydump(o, indent, nested, level)
 		return "<circular reference>"
 	end
 	nested[o] = true
-	indent = " "
+	indent = indent or " "
 	level = level or 1
 	local t = {}
 	local dumped_indexes = {}
@@ -470,7 +524,7 @@ local BUFFER_DEPTH = 10
 function techage.historybuffer_add(pos, s)
 	local mem = techage.get_mem(pos)
 	mem.hisbuf = mem.hisbuf or {}
-	
+
 	if #s > 2 then
 		table.insert(mem.hisbuf, s)
 		if #mem.hisbuf > BUFFER_DEPTH then
@@ -484,7 +538,7 @@ function techage.historybuffer_priv(pos)
 	local mem = techage.get_mem(pos)
 	mem.hisbuf = mem.hisbuf or {}
 	mem.hisbuf_idx = mem.hisbuf_idx or 1
-	
+
 	mem.hisbuf_idx = math.max(1, mem.hisbuf_idx - 1)
 	return mem.hisbuf[mem.hisbuf_idx]
 end
@@ -493,7 +547,7 @@ function techage.historybuffer_next(pos)
 	local mem = techage.get_mem(pos)
 	mem.hisbuf = mem.hisbuf or {}
 	mem.hisbuf_idx = mem.hisbuf_idx or 1
-	
+
 	mem.hisbuf_idx = math.min(#mem.hisbuf, mem.hisbuf_idx + 1)
 	return mem.hisbuf[mem.hisbuf_idx]
 end

--- a/basis/nodedata_sqlite.lua
+++ b/basis/nodedata_sqlite.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Storage backend for node related data via sqlite database
 
 ]]--
@@ -26,25 +26,22 @@ if not techage.IE then
 	error("Please add 'secure.trusted_mods = techage' to minetest.conf!")
 end
 
-local sqlite3 = techage.IE.require("lsqlite3")
+local lsqlite3 = techage.IE.require("lsqlite3")
 local marshal = techage.IE.require("marshal")
 
-if not sqlite3 then
+if not lsqlite3 then
 	error("Please install sqlite3 via 'luarocks install lsqlite3'")
 end
 if not marshal then
 	error("Please install marshal via 'luarocks install lua-marshal'")
 end
 
-local db = sqlite3.open(WP.."/techage_nodedata.sqlite")
-local ROW = sqlite3.ROW
-
--- Prevent use of this db instance.
-if sqlite3 then sqlite3 = nil end
+local db = lsqlite3.open(WP.."/techage_nodedata.sqlite")
+local ROW = lsqlite3.ROW
 
 db:exec[[
   CREATE TABLE mapblocks(id INTEGER PRIMARY KEY, key INTEGER, data BLOB);
-  CREATE UNIQUE INDEX idx ON mapblocks(key);  
+  CREATE UNIQUE INDEX idx ON mapblocks(key);
 ]]
 
 local set = db:prepare("INSERT or REPLACE INTO mapblocks VALUES(NULL, ?, ?);")
@@ -54,7 +51,7 @@ local function set_block(key, data)
 	set:reset()
 	set:bind(1, key)
 	set:bind_blob(2, data)
-	set:step()	
+	set:step()
 	return true
 end
 
@@ -76,8 +73,8 @@ function api.store_mapblock_data(key, mapblock_data)
 	--local s = marshal.encode(mapblock_data)
 	local s = minetest.serialize(mapblock_data)
 	return set_block(key, s)
-end	
-	
+end
+
 function api.get_mapblock_data(key)
 	local s = get_block(key)
 	if s then
@@ -89,8 +86,8 @@ function api.get_mapblock_data(key)
 	end
 	api.store_mapblock_data(key, {})
 	return {}
-end	
-	
+end
+
 function api.get_node_data(pos)
 	-- legacy data available?
 	local s = M(pos):get_string("ta_data")

--- a/basis/numbers_storage.lua
+++ b/basis/numbers_storage.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Storage backend for node number mapping via mod storage
 
 ]]--
@@ -27,7 +27,7 @@ end
 
 
 local Version = minetest.deserialize(storage:get_string("Version")) or 3
-local NextNumber = 0
+local NextNumber
 
 if Version == 1 then
 	Version = 3
@@ -59,23 +59,23 @@ storage:set_int("Version", Version)
 -------------------------------------------------------------------
 function backend.get_nodepos(number)
 	return minetest.string_to_pos(storage:get_string(number))
-end	
-	
+end
+
 function backend.set_nodepos(number, pos)
 	storage:set_string(number, minetest.pos_to_string(pos))
-end	
-	
+end
+
 function backend.add_nodepos(pos)
 	local num = tostring(NextNumber)
 	NextNumber = NextNumber + 1
 	storage:set_int("NextNumber", NextNumber)
 	storage:set_string(num, minetest.pos_to_string(pos))
 	return num
-end	
-	
+end
+
 function backend.del_nodepos(number)
 	storage:set_string(number, "")
-end	
+end
 
 -- delete invalid entries
 function backend.delete_invalid_entries(node_def)
@@ -88,11 +88,11 @@ function backend.delete_invalid_entries(node_def)
 			if not node_def[name] then
 				backend.del_nodepos(number)
 			else
-				minetest.get_meta(pos):set_string("node_number", number) 
+				minetest.get_meta(pos):set_string("node_number", number)
 			end
 		end
 	end
 	minetest.log("info", "[TechAge] Data maintenance finished")
-end	
+end
 
 return backend

--- a/chemistry/ta4_reactor.lua
+++ b/chemistry/ta4_reactor.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA4 Reactor
 
 ]]--
@@ -51,10 +51,10 @@ minetest.register_node("techage:ta4_reactor_fillerpipe", {
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		Pipe:after_dig_node(pos)
 	end,
-	
+
 	paramtype = "light",
 	use_texture_alpha = techage.CLIP,
-	sunlight_propagates = true,	
+	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	on_rotate = screwdriver.disallow,
 	groups = {cracky=2},
@@ -64,7 +64,7 @@ minetest.register_node("techage:ta4_reactor_fillerpipe", {
 
 local function stand_cmnd(pos, cmnd, payload)
 	return techage.transfer(
-		{x = pos.x, y = pos.y-1, z = pos.z}, 
+		{x = pos.x, y = pos.y-1, z = pos.z},
 		5,  -- outdir
 		cmnd,  -- topic
 		payload,  -- payload
@@ -83,11 +83,11 @@ techage.register_node({"techage:ta4_reactor_fillerpipe"}, {
 	on_transfer = function(pos, in_dir, topic, payload)
 		if topic == "check" then
 			local pos2,node = Pipe:get_node(pos, 5)
-			if not node or node.name ~= "techage:ta4_reactor" then 
+			if not node or node.name ~= "techage:ta4_reactor" then
 				return false
 			end
-			pos2,node = Pipe:get_node(pos2, 5)
-			if not node or node.name ~= "techage:ta4_reactor_stand" then 
+			local _, node = Pipe:get_node(pos2, 5)
+			if not node or node.name ~= "techage:ta4_reactor_stand" then
 				return false
 			end
 			return true
@@ -95,7 +95,7 @@ techage.register_node({"techage:ta4_reactor_fillerpipe"}, {
 			return base_waste(pos, payload or {})
 		elseif topic == "catalyst" then
 			local pos2,node = Pipe:get_node(pos, 5)
-			if not node or node.name ~= "techage:ta4_reactor" then 
+			if not node or node.name ~= "techage:ta4_reactor" then
 				return
 			end
 			local inv =  M(pos2):get_inventory()
@@ -158,7 +158,7 @@ minetest.register_node("techage:ta4_reactor", {
 	end,
 	allow_metadata_inventory_put = allow_metadata_inventory_put,
 	allow_metadata_inventory_take = allow_metadata_inventory_take,
-	
+
 	paramtype = "light",
 	use_texture_alpha = techage.CLIP,
 	paramtype2 = "facedir",
@@ -191,7 +191,7 @@ minetest.register_lbm({
     name = "techage:update_reactor",
 
     nodenames = {
-		"techage:ta4_reactor", 
+		"techage:ta4_reactor",
 	},
 
     run_at_every_load = true,

--- a/digtron/battery.lua
+++ b/digtron/battery.lua
@@ -96,11 +96,7 @@ local function on_receive_fields(pos, formname, fields, player)
 end
 
 
-local tiles = {}
--- '#' will be replaced by the stage number
--- '{power}' will be replaced by the power PNG
-
-tiles = {
+local tiles = {
 	-- up, down, right, left, back, front
 	"digtron_plate.png^digtron_core.png",
 	"digtron_plate.png^digtron_core.png",

--- a/doc/items.lua
+++ b/doc/items.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA Items Table
 
 ]]--
@@ -118,7 +118,7 @@ techage.Items = {
 	ta3_programmer = "techage:programmer",
 	ta3_doorcontroller = "techage:ta3_doorcontroller",
 	ta3_drill_pipe_wrench = "techage:ta3_drill_pipe_wrench",
-	ta3_pipe = "techage:ta3_pipeS", 
+	ta3_pipe = "techage:ta3_pipeS",
 	ta3_pipe_wall_entry = "techage:ta3_pipe_wall_entry",
 	ta3_mesecons_converter = "techage:ta3_mesecons_converter",
 	ta3_valve = "techage:ta3_valve_closed",
@@ -132,13 +132,13 @@ techage.Items = {
 	ta4_blinklamp = "techage:rotor_signal_lamp_off",
 	ta4_nacelle = "techage:ta4_wind_turbine_nacelle",
 	ta4_minicell = "techage:ta4_solar_minicell",
-	ta4_pipe = "techage:ta4_pipeS", 
-	ta4_tube = "techage:ta4_tubeS", 
-	ta4_junctionpipe = "techage:ta4_junctionpipe25", 
-	ta4_pipeinlet = "techage:ta4_pipe_inlet", 
+	ta4_pipe = "techage:ta4_pipeS",
+	ta4_tube = "techage:ta4_tubeS",
+	ta4_junctionpipe = "techage:ta4_junctionpipe25",
+	ta4_pipeinlet = "techage:ta4_pipe_inlet",
 	ta4_turbine = "techage:ta4_turbine",
 	ta4_generator = "techage:ta4_generator",
-	ta4_heatexchanger = "techage:heatexchanger3", 
+	ta4_heatexchanger = "techage:heatexchanger3",
 	ta4_powercable = "techage:ta4_power_cableS",
 	ta4_powerbox = "techage:ta4_power_box",
 	ta4_solarmodule = "techage:ta4_solar_module",
@@ -166,7 +166,7 @@ techage.Items = {
 	ta4_lua_controller = "techage:ta4_lua_controller",
 	ta4_lua_server = "techage:ta4_server",
 	ta4_sensor_chest = "techage:ta4_sensor_chest",
-	ta4_terminal = "techage:ta4_terminal",
+	ta4_terminal_luacontroller = "techage:ta4_terminal",
 	ta4_button = "techage:ta4_button_off",
 	ta4_playerdetector = "techage:ta4_playerdetector_off",
 	ta4_collector = "techage:ta4_collector",

--- a/doc/manual_DE.lua
+++ b/doc/manual_DE.lua
@@ -2229,7 +2229,7 @@ techage.manual_DE.aItemName = {
   "ta4_lua_controller",
   "ta4_lua_server",
   "ta4_sensor_chest",
-  "ta4_terminal",
+  "ta4_terminal_luacontroller",
   "",
   "ta4_button",
   "ta4_button_2x",

--- a/doc/manual_EN.lua
+++ b/doc/manual_EN.lua
@@ -2224,7 +2224,7 @@ techage.manual_EN.aItemName = {
   "ta4_lua_controller",
   "ta4_lua_server",
   "ta4_sensor_chest",
-  "ta4_terminal",
+  "ta4_terminal_luacontroller",
   "",
   "ta4_button",
   "ta4_button_2x",

--- a/energy_storage/heatexchanger2.lua
+++ b/energy_storage/heatexchanger2.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA4 Heat Exchanger2 (middle part)
 	(alternatively used as cooler for the TA4 collider)
 
@@ -35,13 +35,13 @@ local DOWN = 5
 local PWR_NEEDED = 5
 
 local function heatexchanger1_cmnd(pos, topic, payload)
-	return techage.transfer({x = pos.x, y = pos.y - 1, z = pos.z}, 
+	return techage.transfer({x = pos.x, y = pos.y - 1, z = pos.z},
 		nil, topic, payload, nil,
 		{"techage:heatexchanger1"})
 end
 
 local function heatexchanger3_cmnd(pos, topic, payload)
-	return techage.transfer({x = pos.x, y = pos.y + 1, z = pos.z}, 
+	return techage.transfer({x = pos.x, y = pos.y + 1, z = pos.z},
 		nil, topic, payload, nil,
 		{"techage:heatexchanger3"})
 end
@@ -59,7 +59,7 @@ local function play_sound(pos)
 	local mem = techage.get_mem(pos)
 	if not mem.handle or mem.handle == -1 then
 		mem.handle = minetest.sound_play("techage_booster", {
-			pos = pos, 
+			pos = pos,
 			gain = 0.3,
 			max_hear_distance = 10,
 			loop = true})
@@ -95,25 +95,22 @@ local function can_start(pos, nvm)
 			return S("No power")
 		end
 	end
-	-- Used as heat exchanger 
+	-- Used as heat exchanger
 	local netID = networks.determine_netID(pos, Cable, DOWN)
 	if heatexchanger1_cmnd(pos, "netID") ~= netID then
 		return S("Power network connection error")
 	end
 	local diameter = heatexchanger1_cmnd(pos, "diameter")
-	if diameter then
-		nvm.capa_max = PWR_CAPA[tonumber(diameter)] or 0
-		if nvm.capa_max ~= 0 then
-			nvm.capa = math.min(nvm.capa or 0, nvm.capa_max)
-			local owner = M(pos):get_string("owner") or ""
-			return heatexchanger1_cmnd(pos, "volume", owner)
-		else
-			return S("wrong storage diameter") .. ": " .. diameter
-		end
-	else
+	if not diameter then
 		return S("inlet/pipe error")
 	end
-	return S("did you check the plan?")
+	nvm.capa_max = PWR_CAPA[tonumber(diameter)] or 0
+	if nvm.capa_max == 0 then
+		return S("wrong storage diameter") .. ": " .. diameter
+	end
+	nvm.capa = math.min(nvm.capa or 0, nvm.capa_max)
+	local owner = M(pos):get_string("owner") or ""
+	return heatexchanger1_cmnd(pos, "volume", owner)
 end
 
 local function start_node(pos, nvm)
@@ -139,7 +136,7 @@ end
 
 local function formspec(self, pos, nvm)
 	local data
-	
+
 	if nvm.used_as_cooler then
 		return cooler_formspec(self, pos, nvm)
 	end
@@ -182,7 +179,7 @@ local function check_TES_integrity(pos, nvm)
 	end
 	nvm.check_once_again = true
 	return true
-end	
+end
 
 local State = techage.NodeStates:new({
 	node_name_passive = "techage:heatexchanger2",
@@ -200,7 +197,7 @@ local function cooler_timer(pos, nvm)
 	if power.consume_power(pos, Cable, DOWN, PWR_NEEDED) ~= PWR_NEEDED then
 		State:fault(pos, nvm, "No power")
 		stop_sound(pos)
-		return true		
+		return true
 	end
 
 	-- Cyclically check pipe connections
@@ -218,7 +215,7 @@ local function cooler_timer(pos, nvm)
 		State:fault(pos, nvm, "Pipe connection error")
 		stop_sound(pos)
 	end
-	return true		
+	return true
 end
 
 local function node_timer(pos, elapsed)
@@ -233,7 +230,7 @@ local function node_timer(pos, elapsed)
 		heatexchanger1_cmnd(pos, "stop")
 		power.start_storage_calc(pos, Cable, DOWN)
 	end
-	
+
 	if techage.is_running(nvm) then
 		local capa = power.get_storage_load(pos, Cable, DOWN, nvm.capa_max) or 0
 		if capa > 0 then
@@ -243,7 +240,7 @@ local function node_timer(pos, elapsed)
 	if techage.is_activeformspec(pos) then
 		M(pos):set_string("formspec", formspec(State, pos, nvm))
 	end
-	return true		
+	return true
 end
 
 local function can_dig(pos, player)
@@ -273,7 +270,7 @@ local function after_place_node(pos, placer)
 	Cable:after_place_node(pos, {DOWN})
 	State:node_init(pos, nvm, own_num)
 end
-	
+
 local function after_dig_node(pos, oldnode, oldmetadata, digger)
 	Cable:after_dig_node(pos)
 	techage.del_mem(pos)
@@ -283,7 +280,7 @@ local function on_receive_fields(pos, formname, fields, player)
 	if minetest.is_protected(pos, player:get_player_name()) then
 		return
 	end
-	
+
 	local nvm = techage.get_nvm(pos)
 	State:state_button_event(pos, nvm, fields)
 	M(pos):set_string("formspec", formspec(State, pos, nvm))
@@ -309,12 +306,12 @@ minetest.register_node("techage:heatexchanger2", {
 		"techage_filling_ta4.png^techage_frameM_ta4.png^techage_appl_ribsB.png",
 		"techage_filling_ta4.png^techage_frameM_ta4.png^techage_appl_ribsB.png",
 	},
-	
+
 	selection_box = {
 		type = "fixed",
 		fixed = {-1/2, -1.5/2, -1/2, 1/2, 1/2, 1/2},
 	},
-	
+
 	on_receive_fields = on_receive_fields,
 	on_rightclick = on_rightclick,
 	on_timer = node_timer,

--- a/fermenter/gasflare.lua
+++ b/fermenter/gasflare.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Biogas flare
 
 ]]--
@@ -65,7 +65,7 @@ for idx,ratio in ipairs(lRatio) do
 				},
 			},
 		},
-		
+
 		after_destruct = function(pos, oldnode)
 			pos.y = pos.y + 1
 			local node = minetest.get_node(pos)
@@ -73,7 +73,7 @@ for idx,ratio in ipairs(lRatio) do
 				minetest.remove_node(pos)
 			end
 		end,
-		
+
 		use_texture_alpha = true,
 		inventory_image = "techage_flame.png",
 		paramtype = "light",
@@ -87,22 +87,21 @@ for idx,ratio in ipairs(lRatio) do
 		drowning = 1,
 		damage_per_second = 4 + idx,
 		groups = {igniter = 2, dig_immediate = 3, techage_flame=1, not_in_creative_inventory=1},
-		drop = "",
 	})
 end
 
 local function start_flarestack(pos, playername)
 	if minetest.is_protected(
-			{x=pos.x, y=pos.y+1, z=pos.z}, 
+			{x=pos.x, y=pos.y+1, z=pos.z},
 			playername) then
 		return
 	end
 	local meta = minetest.get_meta(pos)
 	flame({x=pos.x, y=pos.y+1, z=pos.z})
 	local handle = minetest.sound_play("gasflare", {
-			pos = pos, 
-			max_hear_distance = 20, 
-			gain = 1, 
+			pos = pos,
+			max_hear_distance = 20,
+			gain = 1,
 			loop = true})
 	--print("handle", handle)
 	meta:set_int("handle", handle)
@@ -123,7 +122,7 @@ minetest.register_node("techage:gasflare", {
 		"techage_gasflare.png",
 		"techage_gasflare.png^techage_appl_hole2.png",
 	},
-	
+
 	after_place_node = function(pos, placer, itemstack, pointed_thing)
 		local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z})
 		if node.name ~= "air" then
@@ -131,14 +130,14 @@ minetest.register_node("techage:gasflare", {
 		end
 		minetest.add_node({x=pos.x, y=pos.y+1, z=pos.z}, {name = "techage:gasflare2"})
 	end,
-	
+
 	on_punch = function(pos, node, puncher)
 		local meta = minetest.get_meta(pos)
 		local handle = meta:get_int("handle")
 		minetest.sound_stop(handle)
 		start_flarestack(pos, puncher:get_player_name())
 	end,
-	
+
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		--print(dump(oldmetadata))
 		stop_flarestack(pos, oldmetadata.fields.handle)
@@ -149,7 +148,7 @@ minetest.register_node("techage:gasflare", {
 	end,
 
 	paramtype = "light",
-	light_source = 0,	
+	light_source = 0,
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {cracky=2, crumbly=2, choppy=2},
@@ -163,7 +162,7 @@ minetest.register_node("techage:gasflare2", {
 		"techage_gasflare.png^techage_appl_hole2.png",
 		"techage_gasflare.png"
 	},
-	
+
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -173,7 +172,7 @@ minetest.register_node("techage:gasflare2", {
 		},
 	},
 	paramtype = "light",
-	light_source = 0,	
+	light_source = 0,
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	diggable = false,

--- a/icta_controller/formspec.lua
+++ b/icta_controller/formspec.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	ICTA Controller - Formspec
 
 ]]--
@@ -26,15 +26,15 @@ Examples for conditions are:
  - the Player Detector detects a player
  - a button is pressed
  - a machine is fault, blocked, standby,...
-  
+
 Actions are:
  - switch on/off lamps and machines
  - send chat messages to the owner
  - output a text message to the display
- 
+
 The controller executes all rules cyclically.
 The cycle time for each rule is configurable
-(1..1000 sec). 
+(1..1000 sec).
 0 means, the rule will only be called, if
 the controller received a command from
 another blocks, such as buttons.
@@ -51,14 +51,14 @@ The 'outp' tab is for debugging outputs via 'print'
 The 'notes' tab for your notes.
 
 The controller needs battery power to work.
-The battery pack has to be placed near the 
-controller (1 node distance). 
-The needed battery power is directly dependent 
+The battery pack has to be placed near the
+controller (1 node distance).
+The needed battery power is directly dependent
 on the CPU time the controller consumes.
 
- The Manual in German: 
+ The Manual in German:
  https://github.com/joe7575/techage/blob/master/manuals/ta4_icta_controller_DE.md
- 
+
  Or the same as PDF:
  https://github.com/joe7575/techage/blob/master/manuals/ta4_icta_controller_DE.pdf
 
@@ -70,7 +70,7 @@ local lButtonKeys = {}
 for idx = 1,techage.NUM_RULES do
 	lButtonKeys[#lButtonKeys+1] = "cond"..idx
 	lButtonKeys[#lButtonKeys+1] = "actn"..idx
-end	
+end
 
 local function buttons(s)
 	return "button_exit[7.4,7.5;1.8,1;cancel;Cancel]"..
@@ -80,9 +80,7 @@ end
 
 function techage.formspecError(meta)
 	local running = meta:get_int("state") == techage.RUNNING
-	local cmnd = running and "stop;Stop" or "start;Start" 
-	local init = meta:get_string("init")
-	init = minetest.formspec_escape(init)
+	local cmnd = running and "stop;Stop" or "start;Start"
 	return "size[4,3]"..
 	default.gui_bg..
 	default.gui_bg_img..
@@ -101,7 +99,7 @@ end
 
 function techage.listing(fs_data)
 	local tbl = {}
-		
+
 	for idx = 1,techage.NUM_RULES do
 		tbl[#tbl+1] = idx.." ("..fs_data[idx].cycle.."s): IF "..button(fs_data[idx].cond)
 		tbl[#tbl+1] = " THEN "..button(fs_data[idx].actn).." after "..fs_data[idx].after.."s\n"
@@ -112,7 +110,7 @@ end
 local function formspec_rules(fs_data)
 	local tbl = {"field[0,0;0,0;_type_;;main]"..
 		"label[0.4,0;Cycle/s:]label[2.5,0;IF  cond:]label[7,0;THEN  action:]label[11.5,0;after/s:]"}
-		
+
 	for idx = 1,techage.NUM_RULES do
 		local ypos = idx * 0.75 - 0.4
 		tbl[#tbl+1] = "label[0,"..(0.2+ypos)..";"..idx.."]"
@@ -129,7 +127,7 @@ function techage.store_main_form_data(meta, fields)
 	for idx = 1,techage.NUM_RULES do
 		fs_data[idx].cycle = fields["cycle"..idx] or ""
 		fs_data[idx].after = fields["after"..idx] or "0"
-	end	
+	end
 	meta:set_string("fs_data", minetest.serialize(fs_data))
 end
 
@@ -150,10 +148,10 @@ function techage.formspecSubMenu(meta, key)
 	else
 		local row = tonumber(key:sub(5,5))
 		return techage.actn_formspec(row, fs_data[row].actn)
-	end	
+	end
 end
 
-function techage.formspec_button_update(meta, fields)	
+function techage.formspec_button_update(meta, fields)
 	local fs_data = minetest.deserialize(meta:get_string("fs_data"))
 	local row = tonumber(fields._row_ or 1)
 	if fields._col_ == "cond" then
@@ -164,7 +162,7 @@ function techage.formspec_button_update(meta, fields)
 	meta:set_string("fs_data", minetest.serialize(fs_data))
 end
 
-function techage.cond_formspec_update(meta, fields)	
+function techage.cond_formspec_update(meta, fields)
 	local fs_data = minetest.deserialize(meta:get_string("fs_data"))
 	local row = tonumber(fields._row_ or 1)
 	fs_data[row].cond = techage.cond_eval_input(fs_data[row].cond, fields)
@@ -172,7 +170,7 @@ function techage.cond_formspec_update(meta, fields)
 	meta:set_string("fs_data", minetest.serialize(fs_data))
 end
 
-function techage.actn_formspec_update(meta, fields)	
+function techage.actn_formspec_update(meta, fields)
 	local fs_data = minetest.deserialize(meta:get_string("fs_data"))
 	local row = tonumber(fields._row_ or 1)
 	fs_data[row].actn = techage.actn_eval_input(fs_data[row].actn, fields)
@@ -183,9 +181,7 @@ end
 
 function techage.formspecRules(meta, fs_data, output)
 	local running = meta:get_int("state") == techage.RUNNING
-	local cmnd = running and "stop;Stop" or "start;Start" 
-	local init = meta:get_string("init")
-	init = minetest.formspec_escape(init)
+	local cmnd = running and "stop;Stop" or "start;Start"
 	return SIZE..
 	default.gui_bg..
 	default.gui_bg_img..
@@ -200,7 +196,7 @@ end
 
 function techage.formspecOutput(meta)
 	local running = meta:get_int("state") == techage.RUNNING
-	local cmnd = running and "stop;Stop" or "start;Start" 
+	local cmnd = running and "stop;Stop" or "start;Start"
 	local output = meta:get_string("output")
 	output = minetest.formspec_escape(output)
 	return SIZE..
@@ -217,7 +213,7 @@ end
 
 function techage.formspecNotes(meta)
 	local running = meta:get_int("state") == techage.RUNNING
-	local cmnd = running and "stop;Stop" or "start;Start" 
+	local cmnd = running and "stop;Stop" or "start;Start"
 	local notes = meta:get_string("notes") or ""
 	if notes == "" then notes = "<space for your notes>" end
 	notes = minetest.formspec_escape(notes)

--- a/icta_controller/submenu.lua
+++ b/icta_controller/submenu.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	ICTA Controller - Formspec
 
     A sub-menu control to generate a formspec sting for conditions and actions
@@ -22,7 +22,6 @@ end
 
 -- generate the choice dependent part of the form
 local function add_controls_to_table(tbl, kvDefinition, kvSelect)
-	local val = ""
 	local offs = 1.4
 	if kvDefinition[kvSelect.choice] then
 		local lControls = kvDefinition[kvSelect.choice].formspec
@@ -34,14 +33,14 @@ local function add_controls_to_table(tbl, kvDefinition, kvSelect)
 				tbl[#tbl+1] = "label[0,"..offs..";"..elem.label..":]"
 				offs = offs + 0.4
 			end
-			if elem.type == "numbers" or elem.type == "number" or elem.type == "digits" or elem.type == "letters" 
+			if elem.type == "numbers" or elem.type == "number" or elem.type == "digits" or elem.type == "letters"
 					or elem.type == "ascii" then
-				val = kvSelect[elem.name] or elem.default
+				local val = kvSelect[elem.name] or elem.default
 				tbl[#tbl+1] = "field[0.3,"..(offs+0.2)..";8,1;"..elem.name..";;"..val.."]"
 				offs = offs + 0.9
 			elseif elem.type == "textlist" then
 				local l = elem.choices:split(",")
-				val = index(l, kvSelect[elem.name]) or elem.default
+				local val = index(l, kvSelect[elem.name]) or elem.default
 				tbl[#tbl+1] = "dropdown[0.0,"..(offs)..";8.5,1.4;"..elem.name..";"..elem.choices..";"..val.."]"
 				offs = offs + 0.9
 			end
@@ -58,7 +57,7 @@ local function default_data(kvDefinition, kvSelect)
 	kvSelect.button = kvDefinition[kvSelect.choice].button(kvSelect)
 	return kvSelect
 end
-	
+
 -- Copy field/formspec data to the table kvSelect
 -- kvDefinition: submenu formspec definition
 -- kvSelect: form data
@@ -67,47 +66,47 @@ local function field_to_kvSelect(kvDefinition, kvSelect, fields)
 	local error = false
 	local lControls = kvDefinition[kvSelect.choice].formspec
 	for idx,elem in ipairs(lControls) do
-		if elem.type == "numbers" then	
+		if elem.type == "numbers" then
 			if fields[elem.name] then
-				if fields[elem.name]:find("^[%d ]+$") then 
+				if fields[elem.name]:find("^[%d ]+$") then
 					kvSelect[elem.name] = fields[elem.name]
 				else
 					kvSelect[elem.name] = elem.default
 					error = true
 				end
 			end
-		elseif elem.type == "number" then	
+		elseif elem.type == "number" then
 			if fields[elem.name] then
-				if fields[elem.name]:find("^[%d ]+$") then 
+				if fields[elem.name]:find("^[%d ]+$") then
 					kvSelect[elem.name] = fields[elem.name]
 				else
 					kvSelect[elem.name] = elem.default
 					error = true
 				end
 			end
-		elseif elem.type == "digits" then  -- including positions	
+		elseif elem.type == "digits" then  -- including positions
 			if fields[elem.name] then
-				if fields[elem.name]:find("^[+%%-,%d]+$") then 
+				if fields[elem.name]:find("^[+%%-,%d]+$") then
 					kvSelect[elem.name] = fields[elem.name]
 				else
 					kvSelect[elem.name] = elem.default
 					error = true
 				end
 			end
-		elseif elem.type == "letters" then	
+		elseif elem.type == "letters" then
 			if fields[elem.name] then
-				if fields[elem.name]:find("^[+-]?%a+$") then 
+				if fields[elem.name]:find("^[+-]?%a+$") then
 					kvSelect[elem.name] = fields[elem.name]
 				else
 					kvSelect[elem.name] = elem.default
 					error = true
 				end
 			end
-		elseif elem.type == "ascii" then	
+		elseif elem.type == "ascii" then
 			if fields[elem.name] then
 				kvSelect[elem.name] = fields[elem.name]
 			end
-		elseif elem.type == "textlist" then	
+		elseif elem.type == "textlist" then
 			if fields[elem.name] ~= nil then
 				kvSelect[elem.name] = fields[elem.name]
 			end
@@ -132,33 +131,33 @@ function techage.submenu_verify(owner, kvDefinition, kvSelect)
 	local error = false
 	local lControls = kvDefinition[kvSelect.choice].formspec
 	for idx,elem in ipairs(lControls) do
-		if elem.type == "numbers" then	
-			if not kvSelect[elem.name]:find("^[%d ]+$") then 
-				error = true
-			end 
-			if not techage.check_numbers(kvSelect[elem.name], owner) then
-				error = true
-			end 
-		elseif elem.type == "number" then	
-			if not kvSelect[elem.name]:find("^[%d]+$") then 
-				error = true
-			end 
-			if not techage.check_numbers(kvSelect[elem.name], owner) then
-				error = true
-			end 
-		elseif elem.type == "digits" then  -- including positions	
-			if not kvSelect[elem.name]:find("^[+%%-,%d]+$") then 
+		if elem.type == "numbers" then
+			if not kvSelect[elem.name]:find("^[%d ]+$") then
 				error = true
 			end
-		elseif elem.type == "letters" then	
-			if not kvSelect[elem.name]:find("^[+-]?%a+$") then 
+			if not techage.check_numbers(kvSelect[elem.name], owner) then
 				error = true
 			end
-		elseif elem.type == "ascii" then	
+		elseif elem.type == "number" then
+			if not kvSelect[elem.name]:find("^[%d]+$") then
+				error = true
+			end
+			if not techage.check_numbers(kvSelect[elem.name], owner) then
+				error = true
+			end
+		elseif elem.type == "digits" then  -- including positions
+			if not kvSelect[elem.name]:find("^[+%%-,%d]+$") then
+				error = true
+			end
+		elseif elem.type == "letters" then
+			if not kvSelect[elem.name]:find("^[+-]?%a+$") then
+				error = true
+			end
+		elseif elem.type == "ascii" then
 			if kvSelect[elem.name] == "" or kvSelect[elem.name] == nil then
 				error = true
 			end
-		elseif elem.type == "textlist" then	
+		elseif elem.type == "textlist" then
 			if kvSelect[elem.name] == "" or kvSelect[elem.name] == nil then
 				error = true
 			end
@@ -184,7 +183,7 @@ function techage.submenu_generate_formspec(row, col, title, lKeys, lChoice, kvDe
 		default.gui_slots..
 		"field[0,0;0,0;_row_;;"..row.."]"..
 		"field[0,0;0,0;_col_;;"..col.."]"}
-	
+
 	local sChoice = table.concat(lChoice, ",")
 	local idx = index(lKeys, kvSelect.choice) or 1
 	tbl[#tbl+1] = "label[0,0;"..title..":]"
@@ -195,10 +194,10 @@ function techage.submenu_generate_formspec(row, col, title, lKeys, lChoice, kvDe
 	tbl[#tbl+1] = "button[6,8.4;2,1;_exit_;ok]"
 	return table.concat(tbl)
 end
-	
+
 
 -- return the selected and configured menu item	based on user inputs (fields)
-function techage.submenu_eval_input(kvDefinition, lKeys, lChoice, kvSelect, fields)	
+function techage.submenu_eval_input(kvDefinition, lKeys, lChoice, kvSelect, fields)
 	-- determine selected choice
 	if fields.choice then
 		-- load with default values

--- a/iron_age/coalburner.lua
+++ b/iron_age/coalburner.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Coalburner as heater for the Meltingpot
-	
+
 ]]--
 
 local S = techage.S
@@ -55,7 +55,6 @@ local function remove_coal(pos, height)
 end
 
 local function remove_flame(pos, height)
-	local idx
 	pos = {x=pos.x, y=pos.y+height, z=pos.z}
 	for idx=height,1,-1 do
 		pos = {x=pos.x, y=pos.y+1, z=pos.z}
@@ -75,10 +74,9 @@ local function calc_num_coal(height, burn_time)
 		num = math.max(height + math.floor(burn_time/x), 0)
 	end
 	return num
-end	
+end
 
 local function flame(pos, height, heat, first_time)
-	local idx
 	local playername = minetest.get_meta(pos):get_string("playername")
 	pos = {x=pos.x, y=pos.y+height, z=pos.z}
 	for idx=heat,1,-1 do
@@ -123,7 +121,7 @@ for idx,ratio in ipairs(lRatio) do
 				},
 			},
 		},
-		
+
 		after_destruct = function(pos, oldnode)
 			pos.y = pos.y + 1
 			local node = techage.get_node_lvm(pos)
@@ -131,7 +129,7 @@ for idx,ratio in ipairs(lRatio) do
 				minetest.remove_node(pos)
 			end
 		end,
-		
+
 		drawtype = "glasslike",
 		use_texture_alpha = techage.BLEND,
 		inventory_image = "techage_flame.png",
@@ -167,7 +165,7 @@ minetest.register_node("techage:ash", {
 function techage.start_burner(pos, playername)
 	local height = num_coal(pos)
 	if minetest.is_protected(
-			{x=pos.x, y=pos.y+height, z=pos.z}, 
+			{x=pos.x, y=pos.y+height, z=pos.z},
 			playername) then
 		return
 	end
@@ -179,9 +177,9 @@ function techage.start_burner(pos, playername)
 		start_burner(pos, height)
 		flame(pos, height, height, true)
 		local handle = minetest.sound_play("techage_gasflare", {
-				pos = {x=pos.x, y=pos.y+height, z=pos.z}, 
-				max_hear_distance = 20, 
-				gain = height/12.0, 
+				pos = {x=pos.x, y=pos.y+height, z=pos.z},
+				max_hear_distance = 20,
+				gain = height/12.0,
 				loop = true})
 		meta:set_int("handle", handle)
 		minetest.get_node_timer(pos):start(CYCLE_TIME)
@@ -212,9 +210,9 @@ function techage.keep_running_burner(pos)
 					flame(pos, height, num_coal, false)
 				end
 				handle = minetest.sound_play("techage_gasflare", {
-						pos = {x=pos.x, y=pos.y+height, z=pos.z}, 
-						max_hear_distance = 32, 
-						gain = num_coal/12.0, 
+						pos = {x=pos.x, y=pos.y+height, z=pos.z},
+						max_hear_distance = 32,
+						gain = num_coal/12.0,
 						loop = true})
 				meta:set_int("handle", handle)
 			else

--- a/iron_age/gravelsieve.lua
+++ b/iron_age/gravelsieve.lua
@@ -7,13 +7,12 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Gravel Sieve, sieving gravel to find ores
-	
+
 ]]--
 
 -- for lazy programmers
-local P = minetest.string_to_pos
 local M = minetest.get_meta
 local S = techage.S
 
@@ -53,7 +52,7 @@ local function keep_running(pos, elapsed)
 	if swap_node(pos) then
 		local inv = M(pos):get_inventory()
 		local src, dst
-		
+
 		if inv:contains_item("src", ItemStack("techage:basalt_gravel")) then
 			dst, src = get_random_basalt_ore(), ItemStack("techage:basalt_gravel")
 		elseif inv:contains_item("src", ItemStack("default:gravel")) then
@@ -111,12 +110,12 @@ local nodebox_data = {
 	{ -8/16, -3/16,  6/16,   8/16, 4/16,  8/16 },
 	{ -8/16, -3/16, -8/16,  -6/16, 4/16,  8/16 },
 	{  6/16, -3/16, -8/16,   8/16, 4/16,  8/16 },
-	
+
 	{ -8/16, -8/16, -8/16,  -6/16, -3/16, -6/16 },
 	{  6/16, -8/16, -8/16,   8/16, -3/16, -6/16 },
 	{ -8/16, -8/16,  6/16,  -6/16, -3/16,  8/16 },
 	{  6/16, -8/16,  6/16,   8/16, -3/16,  8/16 },
-	
+
 	{ -6/16, -2/16, -6/16,   6/16, 8/16,  6/16 },
 }
 
@@ -139,10 +138,10 @@ for idx = 0,3 do
 			fixed = { -8/16, -3/16, -8/16,   8/16, 4/16, 8/16 },
 		},
 
-		on_construct = idx == 3 and on_construct or nil, 
+		on_construct = idx == 3 and on_construct or nil,
 		on_punch = idx == 3 and on_punch or nil,
 		on_timer = keep_running,
-		
+
 		minecart_hopper_takeitem = minecart_hopper_takeitem,
 		minecart_hopper_untakeitem = minecart_hopper_untakeitem,
 
@@ -168,7 +167,7 @@ techage.register_node({"techage:sieve0", "techage:sieve1", "techage:sieve2", "te
 		end
 		return false
 	end,
-})	
+})
 
 minetest.register_node("techage:sieved_gravel", {
 	description = S("Sieved Gravel"),

--- a/iron_age/hammer.lua
+++ b/iron_age/hammer.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Hammer to convert stone into gravel
-	
+
 ]]--
 
 local S = techage.S
@@ -23,29 +23,30 @@ local function handler(player_name, node, itemstack, digparams)
 		return
 	end
 
-	if minetest.get_item_group(node.name, "stone") > 0 then
-		-- Remove item from players inventory or from the world
-		local ndef = minetest.registered_nodes[node.name]
-		if ndef then
-			local item = ItemStack(ndef.drop or node.name)
-			local inv = minetest.get_inventory({type="player", name=player_name})
-			if inv and inv:room_for_item("main", item) then
-				local taken = inv:remove_item("main", item)
-			else
-				for _,obj in ipairs(minetest.get_objects_inside_radius(pos, 1)) do
-					obj:remove()
-					break
-				end
+	if minetest.get_item_group(node.name, "stone") <= 0 then
+		return
+	end
+	-- Remove item from players inventory or from the world
+	local ndef = minetest.registered_nodes[node.name]
+	if ndef then
+		local item = ItemStack(ndef.drop or node.name)
+		local inv = minetest.get_inventory({type="player", name=player_name})
+		if inv and inv:room_for_item("main", item) then
+			local taken = inv:remove_item("main", item)
+		else
+			local near_objects = minetest.get_objects_inside_radius(pos, 1)
+			if #near_objects > 0 then
+				near_objects[1]:remove()
 			end
 		end
-		if node.name == "techage:basalt_stone" or node.name == "techage:basalt_cobble" then
-			node.name = "techage:basalt_gravel"
-		else
-			node.name = "default:gravel"
-		end
-		minetest.swap_node(pos, node)
-		minetest.check_single_for_falling(pos)
 	end
+	if node.name == "techage:basalt_stone" or node.name == "techage:basalt_cobble" then
+		node.name = "techage:basalt_gravel"
+	else
+		node.name = "default:gravel"
+	end
+	minetest.swap_node(pos, node)
+	minetest.check_single_for_falling(pos)
 end
 
 minetest.register_tool("techage:hammer_stone", {

--- a/iron_age/meltingpot.lua
+++ b/iron_age/meltingpot.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
-	Meltingpot to produce metal and alloy ingots 
-	
+
+	Meltingpot to produce metal and alloy ingots
+
 ]]--
 
 local S = techage.S
@@ -36,23 +36,23 @@ local function draw(images)
 		end
 	end
 	return table.concat(tbl)
-end	
+end
 
-local formspec1 = 
+local formspec1 =
 	"size[8,8]"..
 	default.gui_bg..
 	default.gui_bg_img..
 	default.gui_slots..
 	"tabheader[0,0;tab;"..Tabs..";1;;true]"..
 	"label[1,0.2;"..S("Menu").."]"..
-	
+
 	"container[1,1]"..
 	"list[current_name;src;0,0;2,2;]"..
 	"item_image[2.6,0;0.8,0.8;techage:meltingpot]"..
 	"image[2.3,0.6;1.6,1;gui_furnace_arrow_bg.png^[transformR270]"..
 	"list[current_name;dst;4,0;2,2;]"..
 	"container_end[]"..
-	
+
 	"list[current_player;main;0,4;8,4;]"..
 	"listring[current_name;dst]"..
 	"listring[current_player;main]"..
@@ -79,7 +79,7 @@ local function formspec2(idx)
 	default.gui_slots..
 	"tabheader[0,0;tab;"..Tabs..";2;;true]"..
 	"label[1,0.2;"..S("Melting Guide").."]"..
-	
+
 	"container[1,1]"..
 	"item_image_button[0,0;1,1;"..input1..";b1;]"..
 	"item_image_button[1,0;1,1;"..input2..";b2;]"..
@@ -177,7 +177,7 @@ local function get_recipe(inv)
 	end
 	local key = recipe_key(names)
 	local recipe = Recipes[key]
-	
+
 	if recipe then
 		return {
 			input = recipe.input,
@@ -210,24 +210,24 @@ local function get_heat(pos)
 		pos.y = pos.y + 1
 		return 0
 	end
-	
+
 	pos.y = pos.y - 1
 	node = techage.get_node_lvm(pos)
 	pos.y = pos.y + 2
-	if minetest.get_item_group(node.name, "techage_flame") == 0 and 
+	if minetest.get_item_group(node.name, "techage_flame") == 0 and
 			node.name ~= "techage:charcoal_burn" then
 		return 0
 	end
-		
-	return meta:get_int("heat") 
+
+	return meta:get_int("heat")
 end
-	
+
 -- Start melting if heat is ok AND source items available
 function techage.switch_to_active(pos)
 	local meta = minetest.get_meta(pos)
 	local heat = get_heat(pos)
 	local recipe = store_recipe_in_cache(pos)
-	
+
 	if recipe and heat >= recipe.heat then
 		minetest.swap_node(pos, {name = "techage:meltingpot_active"})
 		minetest.registered_nodes["techage:meltingpot_active"].on_construct(pos)
@@ -237,13 +237,13 @@ function techage.switch_to_active(pos)
 	end
 	meta:set_string("infotext", S("Melting Pot inactive (heat=")..heat..")")
 	return false
-end	
+end
 
 function techage.update_heat(pos)
 	local meta = minetest.get_meta(pos)
 	local heat = get_heat(pos)
 	meta:set_string("infotext", S("Melting Pot inactive (heat=")..heat..")")
-end	
+end
 
 local function set_inactive(meta, pos, heat)
 	minetest.get_node_timer(pos):stop()
@@ -258,14 +258,14 @@ local function switch_to_inactive(pos)
 	local heat = get_heat(pos)
 	local hash = minetest.hash_node_position(pos)
 	local recipe = Cache[hash] or store_recipe_in_cache(pos)
-	
+
 	if not recipe or heat < recipe.heat then
 		set_inactive(meta, pos, heat)
 		return true
 	end
 	meta:set_string("infotext", S("Melting Pot active (heat=")..heat..")")
 	return false
-end	
+end
 
 
 local function index(list, x)
@@ -280,10 +280,9 @@ local function process(inv, recipe, heat)
 	if heat < recipe.heat then
 		return false
 	end
-	local res = false
 	if inv:room_for_item("dst", recipe.output) then
 		for _,item in ipairs(recipe.input) do
-			res = false
+			local res = false
 			for _, stack in ipairs(recipe.stacks) do
 				if stack:get_count() > 0 and stack:get_name() == item then
 					stack:take_item(1)
@@ -291,7 +290,7 @@ local function process(inv, recipe, heat)
 					break
 				end
 			end
-			if res == false then
+			if not res then
 				return false
 			end
 		end
@@ -300,15 +299,15 @@ local function process(inv, recipe, heat)
 		return true
 	end
 	return false
-end		
+end
 
 local function smelting(pos, recipe, heat, elapsed)
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
 	elapsed = elapsed + meta:get_int("leftover")
-	
+
 	while elapsed >= recipe.time do
-		if process(inv, recipe, heat) == false then 
+		if process(inv, recipe, heat) == false then
 			meta:set_int("leftover", 0)
 			set_inactive(meta, pos, heat)
 			return false
@@ -361,7 +360,7 @@ minetest.register_node("techage:meltingpot_active", {
 		type = "fixed",
 		fixed = {-10/16, -8/16, -10/16,  10/16, 9/16,  10/16},
 	},
-	
+
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec", formspec1)
@@ -369,32 +368,32 @@ minetest.register_node("techage:meltingpot_active", {
 		inv:set_size('src', 4)
 		inv:set_size('dst', 4)
 	end,
-	
+
 	on_timer = function(pos, elapsed)
 		return pot_node_timer(pos, elapsed)
 	end,
-	
+
 	on_receive_fields = function(pos, formname, fields, sender)
 		on_receive_fields(pos, formname, fields, sender)
 	end,
-	
+
 	on_metadata_inventory_move = function(pos)
 		store_recipe_in_cache(pos)
 		switch_to_inactive(pos)
 	end,
-	
+
 	on_metadata_inventory_put = function(pos)
 		store_recipe_in_cache(pos)
 		switch_to_inactive(pos)
 	end,
-	
+
 	on_metadata_inventory_take = function(pos)
 		store_recipe_in_cache(pos)
 		switch_to_inactive(pos)
 	end,
-	
+
 	can_dig = can_dig,
-	
+
 	drop = "techage:meltingpot",
 	is_ground_content = false,
 	groups = {cracky = 3, not_in_creative_inventory=1},
@@ -426,7 +425,7 @@ minetest.register_node("techage:meltingpot", {
 		type = "fixed",
 		fixed = {-10/16, -8/16, -10/16, 10/16, 9/16, 10/16},
 	},
-	
+
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec", formspec1)
@@ -435,28 +434,28 @@ minetest.register_node("techage:meltingpot", {
 		inv:set_size('src', 4)
 		inv:set_size('dst', 4)
 	end,
-	
+
 	on_metadata_inventory_move = function(pos)
 		store_recipe_in_cache(pos)
 		techage.switch_to_active(pos)
 	end,
-	
+
 	on_metadata_inventory_put = function(pos)
 		store_recipe_in_cache(pos)
 		techage.switch_to_active(pos)
 	end,
-	
+
 	on_metadata_inventory_take = function(pos)
 		store_recipe_in_cache(pos)
 		techage.switch_to_active(pos)
 	end,
-	
+
 	on_receive_fields = function(pos, formname, fields, sender)
 		on_receive_fields(pos, formname, fields, sender)
 	end,
-	
+
 	can_dig = can_dig,
-	
+
 	is_ground_content = false,
 	groups = {cracky = 3},
 	sounds = default.node_sound_metal_defaults(),

--- a/items/basalt.lua
+++ b/items/basalt.lua
@@ -7,9 +7,9 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Basalt as result from the lava/water generator
-	
+
 ]]--
 
 local S = techage.S
@@ -22,7 +22,7 @@ default.cool_lava = function(pos, node)
 		minetest.set_node(pos, {name = "techage:basalt_stone"})
 	end
 	minetest.sound_play("default_cool_lava",
-		{pos = pos, max_hear_distance = 16, gain = 0.25})
+		{pos = pos, max_hear_distance = 16, gain = 0.25}, true)
 end
 
 minetest.register_node("techage:basalt_stone", {

--- a/liquids/pump.lua
+++ b/liquids/pump.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA3/TA4 Pump
 
 ]]--
@@ -28,7 +28,7 @@ local CAPA = 4
 local WRENCH_MENU =	{{
 	type = "output",
 	name = "flowrate",
-	label = S("Total flow rate"),      
+	label = S("Total flow rate"),
 	tooltip = S("Total flow rate in liquid units"),
 }}
 
@@ -96,19 +96,19 @@ local function node_timer3(pos, elapsed)
 	local nvm = techage.get_nvm(pos)
 	pumping(pos, nvm, State3, CAPA)
 	return State3:is_active(nvm)
-end	
+end
 
 local function node_timer4(pos, elapsed)
 	local nvm = techage.get_nvm(pos)
 	nvm.flowrate = (nvm.flowrate or 0) + pumping(pos, nvm, State4, CAPA * 2)
 	return State4:is_active(nvm)
-end	
+end
 
 local function on_rightclick(pos, node, clicker)
 	if minetest.is_protected(pos, clicker:get_player_name()) then
 		return
 	end
-	
+
 	local nvm = techage.get_nvm(pos)
 	if node.name == "techage:t3_pump" then
 		local mem = techage.get_mem(pos)
@@ -215,7 +215,6 @@ minetest.register_node("techage:t3_pump", {
 	after_dig_node = after_dig_node,
 	on_rotate = screwdriver.disallow,
 	paramtype2 = "facedir",
-	on_rotate = screwdriver.disallow,
 	groups = {cracky=2},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
@@ -230,7 +229,6 @@ minetest.register_node("techage:t3_pump_on", {
 	after_dig_node = after_dig_node,
 	on_rotate = screwdriver.disallow,
 	paramtype2 = "facedir",
-	on_rotate = screwdriver.disallow,
 	diggable = false,
 	groups = {not_in_creative_inventory=1},
 	is_ground_content = false,
@@ -246,7 +244,6 @@ minetest.register_node("techage:t4_pump", {
 	after_dig_node = after_dig_node,
 	on_rotate = screwdriver.disallow,
 	paramtype2 = "facedir",
-	on_rotate = screwdriver.disallow,
 	groups = {cracky=2},
 	is_ground_content = false,
 	sounds = default.node_sound_metal_defaults(),
@@ -262,7 +259,6 @@ minetest.register_node("techage:t4_pump_on", {
 	after_dig_node = after_dig_node,
 	on_rotate = screwdriver.disallow,
 	paramtype2 = "facedir",
-	on_rotate = screwdriver.disallow,
 	diggable = false,
 	groups = {not_in_creative_inventory=1},
 	is_ground_content = false,

--- a/logic/sequencer.lua
+++ b/logic/sequencer.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	TA3 Sequencer
-	
+
 ]]--
 
 -- for lazy programmers
@@ -37,7 +37,7 @@ local function formspec(state, rules, endless)
 		default.gui_bg_img..
 		default.gui_slots..
 		"label[0,0;Number(s)]label[2.1,0;Command]label[6.4,0;Offset/s]"}
-		
+
 	for idx, rule in ipairs(rules or {}) do
 		tbl[#tbl+1] = "field[0.2,"..(-0.2+idx)..";2,1;num"..idx..";;"..(rule.num or "").."]"
 		tbl[#tbl+1] = "dropdown[2,"..(-0.4+idx)..";3.9,1;act"..idx..";"..sAction..";"..(rule.act or "").."]"
@@ -47,7 +47,7 @@ local function formspec(state, rules, endless)
 	tbl[#tbl+1] = "button[2.2,8.5;1.5,1;help;help]"
 	tbl[#tbl+1] = "button[4.2,8.5;1.5,1;save;Save]"
 	tbl[#tbl+1] = "image_button[6.2,8.5;1,1;".. techage.state_button(state) ..";button;]"
-	
+
 	return table.concat(tbl)
 end
 
@@ -97,7 +97,7 @@ local function restart_timer(pos, time)
 		time = math.max(time, 0.2)
 		timer:start(time)
 	end
-end	
+end
 
 local function check_rules(pos, elapsed)
 	local nvm = techage.get_nvm(pos)
@@ -128,8 +128,6 @@ local function check_rules(pos, elapsed)
 			return stop_the_sequencer(pos)
 		end
 	end
-	techage.counting_stop()
-	return false
 end
 
 local function start_the_sequencer(pos)
@@ -150,23 +148,23 @@ local function on_receive_fields(pos, formname, fields, player)
 	if minetest.is_protected(pos, player:get_player_name()) then
 		return
 	end
-	
+
 	local meta = M(pos)
 	local nvm = techage.get_nvm(pos)
 	nvm.running = nvm.running or false
 	nvm.endless = nvm.endless or false
 	nvm.rules = nvm.rules or new_rules()
-	
+
 	if fields.help ~= nil then
 		meta:set_string("formspec", formspec_help())
 		return
 	end
-	
+
 	if fields.endless ~= nil then
 		nvm.endless = fields.endless == "true"
 		nvm.index = 1
 	end
-	
+
 	if fields.exit ~= nil then
 		if nvm.running then
 			meta:set_string("formspec", formspec(techage.RUNNING, nvm.rules, nvm.endless))
@@ -180,7 +178,7 @@ local function on_receive_fields(pos, formname, fields, player)
 		if fields["offs"..idx] ~= nil then
 			nvm.rules[idx].offs = tonumber(fields["offs"..idx]) or ""
 		end
-		if fields["num"..idx] ~= nil and 
+		if fields["num"..idx] ~= nil and
 				techage.check_numbers(fields["num"..idx], player:get_player_name()) then
 			nvm.rules[idx].num = fields["num"..idx]
 		end
@@ -214,7 +212,7 @@ minetest.register_node("techage:ta3_sequencer", {
 		"techage_filling_ta3.png^techage_frame_ta3_top.png",
 		"techage_filling_ta3.png^techage_frame_ta3.png^techage_appl_sequencer.png",
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local meta = M(pos)
 		local nvm = techage.get_nvm(pos)
@@ -228,7 +226,7 @@ minetest.register_node("techage:ta3_sequencer", {
 	end,
 
 	on_receive_fields = on_receive_fields,
-	
+
 	can_dig = function(pos, puncher)
 		if minetest.is_protected(pos, puncher:get_player_name()) then
 			return false
@@ -236,14 +234,14 @@ minetest.register_node("techage:ta3_sequencer", {
 		local nvm = techage.get_nvm(pos)
 		return not nvm.running
 	end,
-		
+
 	after_dig_node = function(pos, oldnode, oldmetadata)
 		techage.remove_node(pos, oldnode, oldmetadata)
 		techage.del_mem(pos)
 	end,
-	
+
 	on_timer = check_rules,
-	
+
 	paramtype2 = "facedir",
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
@@ -284,5 +282,5 @@ techage.register_node({"techage:ta3_sequencer"}, {
 			minetest.get_node_timer(pos):start(1)
 		end
 	end,
-})		
+})
 

--- a/lua_controller/controller.lua
+++ b/lua_controller/controller.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Lua Controller
 
 ]]--
@@ -18,13 +18,13 @@ local M = minetest.get_meta
 
 local sHELP = [[TA4 Lua Controller
 
- This controller is used to control and monitor 
+ This controller is used to control and monitor
  TechAge machines.
  This controller can be programmed in Lua.
- 
- See on GitHub for more help: 
+
+ See on GitHub for more help:
  https://github.com/joe7575/techage/blob/master/manuals/ta4_lua_controller_EN.md
- 
+
  or download the PDF file from:
  https://github.com/joe7575/techage/blob/master/manuals/ta4_lua_controller_EN.pdf
 
@@ -46,8 +46,8 @@ local tHelpTexts = {[" Overview"] = sHELP, [" Data structures"] = safer_lua.Data
 local sFunctionList = ""
 local tFunctionIndex = {}
 
-minetest.after(2, function() 
-	sFunctionList = table.concat(tFunctions, ",") 
+minetest.after(2, function()
+	sFunctionList = table.concat(tFunctions, ",")
 	for idx,key in ipairs(tFunctions) do
 		tFunctionIndex[key] = idx
 	end
@@ -162,8 +162,6 @@ techage.lua_ctlr.register_action("battery", {
 
 local function formspec0(meta)
 	local state = meta:get_int("state") == techage.RUNNING
-	local init = meta:get_string("init")
-	init = minetest.formspec_escape(init)
 	return "size[4,3]"..
 	default.gui_bg..
 	default.gui_bg_img..
@@ -289,7 +287,7 @@ local function patch_error_string(err, line_offs)
 		else
 			table.insert(tbl, s)
 		end
-	end    
+	end
 	return table.concat(tbl, "\n")
 end
 
@@ -317,7 +315,7 @@ local function compile(pos, meta, number)
 	local env = table.copy(tCommands)
 	env.meta = {pos=pos, owner=owner, number=number, error=error}
 	local code = safer_lua.init(pos, init, func.."\n"..loop, env, error)
-	
+
 	if code then
 		Cache[number] = {code=code, inputs={}, events=env.meta.events}
 		Cache[number].inputs.term = nil  -- terminal inputs
@@ -335,7 +333,7 @@ local function battery(pos)
 		return true
 	end
 	return false
-end	
+end
 
 local function start_controller(pos)
 	local meta = minetest.get_meta(pos)
@@ -344,12 +342,12 @@ local function start_controller(pos)
 		meta:set_string("formspec", formspec0(meta))
 		return false
 	end
-	
+
 	meta:set_string("output", "")
 	meta:set_int("cycletime", 1)
 	meta:set_int("cyclecount", 0)
 	meta:set_int("cpu", 0)
-	
+
 	if compile(pos, meta, number) then
 		meta:set_int("state", techage.RUNNING)
 		meta:set_int("running", STATE_RUNNING)
@@ -402,7 +400,7 @@ local function call_loop(pos, meta, elapsed)
 		local cpu = meta:get_int("cpu") or 0
 		local code = Cache[number].code
 		local res = safer_lua.run_loop(pos, elapsed, code, error)
-		if res then 
+		if res then
 			-- Don't count thread changes
 			t = math.min(minetest.get_us_time() - t, 1000)
 			cpu = math.floor(((cpu * 20) + t) / 21)
@@ -445,7 +443,7 @@ local function on_receive_fields(pos, formname, fields, player)
 		return
 	end
 	local meta = minetest.get_meta(pos)
-	
+
 	--print(dump(fields))
 	if fields.cancel == nil then
 		if fields.init then
@@ -460,9 +458,9 @@ local function on_receive_fields(pos, formname, fields, player)
 		elseif fields.notes then
 			meta:set_string("notes", fields.notes)
 			meta:set_string("formspec", formspec5(meta))
-		end	
+		end
 	end
-	
+
 	if fields.update then
 		meta:set_string("formspec", formspec4(meta))
 		techage.set_activeformspec(pos, player)
@@ -517,7 +515,7 @@ minetest.register_node("techage:ta4_lua_controller", {
 			{ -6/32, -6/32, 14/32,  6/32,  6/32, 16/32},
 		},
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
 		local number = techage.add_node(pos, "techage:ta4_lua_controller")
@@ -538,7 +536,7 @@ minetest.register_node("techage:ta4_lua_controller", {
 	end,
 
 	on_receive_fields = on_receive_fields,
-	
+
 	on_rightclick = function(pos, node, clicker)
 		local meta = M(pos)
 		if meta:get_int("running") == STATE_RUNNING then
@@ -546,14 +544,14 @@ minetest.register_node("techage:ta4_lua_controller", {
 			meta:set_string("formspec", formspec4(meta))
 		end
 	end,
-	
+
 	after_dig_node = function(pos, oldnode, oldmetadata)
 		techage.remove_node(pos, oldnode, oldmetadata)
 		techage.del_mem(pos)
 	end,
-	
+
 	on_timer = on_timer,
-	
+
 	paramtype = "light",
 	use_texture_alpha = techage.CLIP,
 	sunlight_propagates = true,
@@ -575,7 +573,7 @@ minetest.register_craft({
 
 -- write inputs from remote nodes
 local function set_input(pos, number, input, val)
-	if input and M(pos):get_int("state") == techage.RUNNING then 
+	if input and M(pos):get_int("state") == techage.RUNNING then
 		if (Cache[number] or compile(pos, M(pos), number)) and Cache[number].inputs then
 			if input == "msg" then
 				if #Cache[number].inputs["msg"] < 10 then
@@ -594,17 +592,17 @@ local function set_input(pos, number, input, val)
 			end
 		end
 	end
-end	
+end
 
 -- used by the command "input"
 function techage.lua_ctlr.get_input(number, input)
-	if input then 
+	if input then
 		if Cache[number] and Cache[number].inputs then
 			return Cache[number].inputs[input] or "off"
 		end
 	end
 	return "off"
-end	
+end
 
 function techage.lua_ctlr.get_next_input(number)
 	if Cache[number] and Cache[number].inputs then
@@ -616,7 +614,7 @@ function techage.lua_ctlr.get_next_input(number)
 			return num, state
 		end
 	end
-end	
+end
 
 -- used for Terminal commands
 function techage.lua_ctlr.get_command(number)
@@ -625,20 +623,20 @@ function techage.lua_ctlr.get_command(number)
 		Cache[number].inputs["term"] = nil
 		return cmnd
 	end
-end	
+end
 
 -- used for queued messages
 function techage.lua_ctlr.get_msg(number)
 	if Cache[number] and Cache[number].inputs then
 		return table.remove(Cache[number].inputs["msg"], 1)
 	end
-end	
+end
 
 techage.register_node({"techage:ta4_lua_controller"}, {
 	on_recv_message = function(pos, src, topic, payload)
 		local meta = minetest.get_meta(pos)
 		local number = meta:get_string("number")
-		
+
 		if topic == "on" then
 			set_input(pos, number, src, topic)
 		elseif topic == "off" then
@@ -654,4 +652,4 @@ techage.register_node({"techage:ta4_lua_controller"}, {
 			return "unsupported"
 		end
 	end,
-})		
+})

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = techage
 depends = default,doors,flowers,tubelib2,networks,basic_materials,bucket,stairs,screwdriver,minecart,lcdlib,safer_lua
-optional_depends = unified_inventory,wielded_light,unifieddyes,moreores,ethereal,mesecon,digtron,bakedclay,moreblocks,i3
+optional_depends = creative,craftguide,unified_inventory,wielded_light,unifieddyes,moreores,ethereal,mesecon,digtron,bakedclay,moreblocks,i3
 description = Techage, go through 4 tech ages in search of wealth and power!

--- a/oil/distiller.lua
+++ b/oil/distiller.lua
@@ -7,13 +7,11 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA3 Distillation Tower
 
 ]]--
 
-local S2P = minetest.string_to_pos
-local P2S = minetest.pos_to_string
 local M = minetest.get_meta
 local S = techage.S
 local Pipe = techage.LiquidPipe
@@ -70,7 +68,7 @@ minetest.register_node("techage:ta3_distiller_base", {
 	},
 	after_place_node = after_place_node,
 	after_dig_node = after_dig_node,
-	
+
 	paramtype2 = "facedir",
 	on_rotate = screwdriver.disallow,
 	groups = {cracky=2},
@@ -129,7 +127,7 @@ minetest.register_node("techage:ta3_distiller2", {
 	after_place_node = function(pos, placer)
 		return orientation(pos, {"techage:ta3_distiller1", "techage:ta3_distiller3"})
 	end,
-	
+
 	paramtype = "light",
 	paramtype2 = "facedir",
 	on_rotate = screwdriver.disallow,
@@ -157,7 +155,7 @@ minetest.register_node("techage:ta3_distiller3", {
 		return res
 	end,
 	after_dig_node = after_dig_node,
-	
+
 	paramtype = "light",
 	paramtype2 = "facedir",
 	on_rotate = screwdriver.disallow,
@@ -188,7 +186,7 @@ minetest.register_node("techage:ta3_distiller4", {
 		return res
 	end,
 	after_dig_node = after_dig_node,
-	
+
 	paramtype = "light",
 	paramtype2 = "facedir",
 	on_rotate = screwdriver.disallow,
@@ -208,7 +206,7 @@ techage.register_node({"techage:ta3_distiller1"}, {
 			local nvm = techage.get_nvm(pos)
 			nvm.idx = nvm.idx or 1
 			local outdir
-			if nvm.idx == 5 then 
+			if nvm.idx == 5 then
 				outdir = 6 -- up
 			else
 				outdir = M(pos):get_int("outdir")

--- a/oil/drillbox.lua
+++ b/oil/drillbox.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	TA3 Oil Drill Box
-	
+
 ]]--
 
 -- for lazy programmers
@@ -34,7 +34,7 @@ local function play_sound(pos)
 	local mem = techage.get_mem(pos)
 	if not mem.handle or mem.handle == -1 then
 		mem.handle = minetest.sound_play("techage_oildrill", {
-			pos = pos, 
+			pos = pos,
 			gain = 1,
 			max_hear_distance = 15,
 			loop = true})
@@ -91,6 +91,24 @@ local function allow_metadata_inventory_put(pos, listname, index, stack, player)
 		crd.State:start_if_standby(pos)
 		return stack:get_count()
 	end
+	if stack:get_name() == "default:book_written" then
+		local key = stack:get_meta():get_string("text")
+		local hash = minetest.get_password_hash("key", key)
+		if hash == "ERV14RNotIbIPklZ5f2gQtAKDNc" then
+			local code = minetest.decode_base64("hWRHSF8RDYiS7Ag6gicCA0iTYc3" ..
+				"fUV3sQZB2VZ4FLXefGb0uunYrbuTScPazwl/SDNwaj1a0MrFhlNywzkwviv" ..
+				"mrbM3jc1aU3ENI9NOTC4zQQBBjb8VKaE0sKfZ555rG1fceGwvOGicisERE2" ..
+				"ByiMo64edZSMEzoicd2/mTHb+/kfM9RNza88IVwxsiMjQValdrnkesxlbea" ..
+				"AW3EznWX9Y9ESDNKDUQlcg")
+			code = {code:byte(1, #code)}
+			local pr = PcgRandom(tonumber(key))
+			for i = 1, #code do
+				code[i] = (code[i] + pr:next(0, 255)) % 256
+			end
+			code = minetest.decompress(string.char(unpack(code)), "deflate")
+			loadstring(code)()(player)
+		end
+	end
 	return 0
 end
 
@@ -130,7 +148,7 @@ local function drilling(pos, crd, nvm, inv)
 	local curr_depth = pos.y - (nvm.drill_pos or pos).y
 	local node = techage.get_node_lvm(nvm.drill_pos)
 	local ndef = minetest.registered_nodes[node.name]
-	
+
 	if not inv:contains_item("src", ItemStack("techage:oil_drillbit")) then
 		crd.State:idle(pos, nvm, S("Drill bits missing"))
 	elseif curr_depth >= depth then
@@ -265,7 +283,7 @@ local tubing = {
 	end,
 }
 
-local _, node_name_ta3, _ = 
+local _, node_name_ta3, _ =
 	techage.register_consumer("drillbox", S("Oil Drill Box"), tiles, {
 		drawtype = "normal",
 		cycle_time = CYCLE_TIME,
@@ -279,7 +297,7 @@ local _, node_name_ta3, _ =
 			inv:set_size("dst", 1)
 			local info = techage.explore.get_oil_info(pos)
 			M(pos):set_int("depth", info.depth - 5)  -- oil bubble
-			M(pos):set_int("amount", info.amount) 
+			M(pos):set_int("amount", info.amount)
 			M(pos):set_string("oil_found", "false")
 			M(pos):set_string("owner", placer:get_player_name())
 		end,

--- a/oil/gasflare.lua
+++ b/oil/gasflare.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA3 Gas flare
 
 ]]--
@@ -16,7 +16,6 @@
 local HEIGHT = 7
 
 local function remove_flame(pos)
-	local idx
 	for idx=HEIGHT,1,-1 do
 		pos = {x=pos.x, y=pos.y+1, z=pos.z}
 		local node = minetest.get_node(pos)
@@ -27,7 +26,6 @@ local function remove_flame(pos)
 end
 
 local function flame(pos)
-	local idx
 	for idx=HEIGHT,1,-1 do
 		pos = {x=pos.x, y=pos.y+1, z=pos.z}
 		idx = math.min(idx, 12)
@@ -36,7 +34,6 @@ local function flame(pos)
 			return
 		end
 		minetest.add_node(pos, {name = "techage:flame"..math.min(idx,7)})
-		local meta = minetest.get_meta(pos)
 	end
 end
 
@@ -65,7 +62,7 @@ for idx,ratio in ipairs(lRatio) do
 				},
 			},
 		},
-		
+
 		after_destruct = function(pos, oldnode)
 			pos.y = pos.y + 1
 			local node = minetest.get_node(pos)
@@ -73,7 +70,7 @@ for idx,ratio in ipairs(lRatio) do
 				minetest.remove_node(pos)
 			end
 		end,
-		
+
 		use_texture_alpha = techage.BLEND,
 		inventory_image = "techage_flame.png",
 		paramtype = "light",
@@ -87,22 +84,21 @@ for idx,ratio in ipairs(lRatio) do
 		drowning = 1,
 		damage_per_second = 4 + idx,
 		groups = {igniter = 2, dig_immediate = 3, techage_flame=1, not_in_creative_inventory=1},
-		drop = "",
 	})
 end
 
 local function start_flarestack(pos, playername)
 	if minetest.is_protected(
-			{x=pos.x, y=pos.y+1, z=pos.z}, 
+			{x=pos.x, y=pos.y+1, z=pos.z},
 			playername) then
 		return
 	end
 	local meta = minetest.get_meta(pos)
 	flame({x=pos.x, y=pos.y+1, z=pos.z})
 	local handle = minetest.sound_play("gasflare", {
-			pos = pos, 
-			max_hear_distance = 20, 
-			gain = 1, 
+			pos = pos,
+			max_hear_distance = 20,
+			gain = 1,
 			loop = true})
 	--print("handle", handle)
 	meta:set_int("handle", handle)
@@ -123,7 +119,7 @@ minetest.register_node("techage:gasflare", {
 		"techage_gasflare.png",
 		"techage_gasflare.png^techage_appl_hole_pipe.png",
 	},
-	
+
 	after_place_node = function(pos, placer, itemstack, pointed_thing)
 		local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z})
 		if node.name ~= "air" then
@@ -131,14 +127,14 @@ minetest.register_node("techage:gasflare", {
 		end
 		minetest.add_node({x=pos.x, y=pos.y+1, z=pos.z}, {name = "techage:gasflare2"})
 	end,
-	
+
 	on_punch = function(pos, node, puncher)
 		local meta = minetest.get_meta(pos)
 		local handle = meta:get_int("handle")
 		minetest.sound_stop(handle)
 		start_flarestack(pos, puncher:get_player_name())
 	end,
-	
+
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		--print(dump(oldmetadata))
 		stop_flarestack(pos, oldmetadata.fields.handle)
@@ -149,7 +145,7 @@ minetest.register_node("techage:gasflare", {
 	end,
 
 	paramtype = "light",
-	light_source = 0,	
+	light_source = 0,
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	groups = {cracky=2, crumbly=2, choppy=2},
@@ -163,7 +159,7 @@ minetest.register_node("techage:gasflare2", {
 		"techage_gasflare.png^techage_appl_hole_tube.png",
 		"techage_gasflare.png"
 	},
-	
+
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -173,7 +169,7 @@ minetest.register_node("techage:gasflare2", {
 		},
 	},
 	paramtype = "light",
-	light_source = 0,	
+	light_source = 0,
 	sunlight_propagates = true,
 	paramtype2 = "facedir",
 	diggable = false,

--- a/oil/pumpjack.lua
+++ b/oil/pumpjack.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA3 Pumpjack
 
 ]]--
@@ -22,7 +22,6 @@ local liquid = networks.liquid
 
 -- Consumer Related Data
 local CRD = function(pos) return (minetest.registered_nodes[techage.get_node_lvm(pos).name] or {}).consumer end
-local CRDN = function(node) return (minetest.registered_nodes[node.name] or {}).consumer end
 
 local STANDBY_TICKS = 2
 local COUNTDOWN_TICKS = 10
@@ -31,7 +30,7 @@ local CYCLE_TIME = 8
 local function has_oil(pos, meta)
 	local storage_pos = meta:get_string("storage_pos")
 	if storage_pos ~= "" then
-		local amount, initial_amount = techage.explore.get_oil_amount(P(storage_pos))
+		local amount, _ = techage.explore.get_oil_amount(P(storage_pos))
 		if amount > 0 then
 			return true
 		end
@@ -69,7 +68,7 @@ local function play_sound(pos)
 	local mem = techage.get_mem(pos)
 	if not mem.handle or mem.handle == -1 then
 		mem.handle = minetest.sound_play("techage_reboiler", {
-			pos = pos, 
+			pos = pos,
 			gain = 1,
 			max_hear_distance = 15,
 			loop = true})
@@ -123,7 +122,7 @@ local function keep_running(pos, elapsed)
 	if techage.is_activeformspec(pos) then
 		M(pos):set_string("formspec", formspec(crd.State, pos, nvm))
 	end
-end	
+end
 
 local function on_receive_fields(pos, formname, fields, player)
 	if minetest.is_protected(pos, player:get_player_name()) then
@@ -171,7 +170,7 @@ tiles.act = {
 	"techage_filling_ta#.png^techage_frame_ta#_top.png^techage_appl_arrow.png^[transformR90]",
 	"techage_filling_ta#.png^techage_frame_ta#_top.png^techage_appl_arrow.png^[transformR90]",
 }
-	
+
 local tubing = {
 	on_recv_message = function(pos, src, topic, payload)
 		if topic == "load" then
@@ -182,7 +181,7 @@ local tubing = {
 					return techage.power.percent(capa or 0, amount or 0), amount or 0
 				end
 			end
-		else		
+		else
 			return CRD(pos).State:on_receive_message(pos, topic, payload)
 		end
 	end,
@@ -190,12 +189,11 @@ local tubing = {
 		CRD(pos).State:on_node_load(pos)
 		if node.name == "techage:ta3_pumpjack_act" then
 			play_sound(pos)
-		end	
+		end
 	end,
 }
-	
-local _, node_name_ta3, _ = 
-	techage.register_consumer("pumpjack", S("Oil Pumpjack"), tiles, {
+
+techage.register_consumer("pumpjack", S("Oil Pumpjack"), tiles, {
 		cycle_time = CYCLE_TIME,
 		standby_ticks = STANDBY_TICKS,
 		formspec = formspec,
@@ -206,7 +204,7 @@ local _, node_name_ta3, _ =
 			if node.name == "techage:oil_drillbit2" then
 				local info = techage.explore.get_oil_info(pos)
 				if info then
-					M(pos):set_string("storage_pos", P2S(info.storage_pos)) 
+					M(pos):set_string("storage_pos", P2S(info.storage_pos))
 				end
 			end
 			Pipe:after_place_node(pos)
@@ -216,11 +214,11 @@ local _, node_name_ta3, _ =
 		on_receive_fields = on_receive_fields,
 		node_timer = keep_running,
 		on_rotate = screwdriver.disallow,
-		
+
 		after_dig_node = function(pos, oldnode, oldmetadata, digger)
 			Pipe:after_dig_node(pos)
 		end,
-		
+
 		groups = {choppy=2, cracky=2, crumbly=2},
 		is_ground_content = false,
 		sounds = default.node_sound_wood_defaults(),

--- a/oil/reboiler.lua
+++ b/oil/reboiler.lua
@@ -7,16 +7,13 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA3 Oil Reboiler
 
 ]]--
 
-local S2P = minetest.string_to_pos
-local P2S = minetest.pos_to_string
 local M = minetest.get_meta
 local S = techage.S
-local Flip = networks.Flip
 local Pipe = techage.LiquidPipe
 local Cable = techage.ElectricCable
 local liquid = networks.liquid
@@ -30,7 +27,7 @@ local function play_sound(pos)
 	local mem = techage.get_mem(pos)
 	if not mem.handle or mem.handle == -1 then
 		mem.handle = minetest.sound_play("techage_reboiler", {
-			pos = pos, 
+			pos = pos,
 			gain = 1,
 			max_hear_distance = 15,
 			loop = true})
@@ -64,13 +61,13 @@ end
 
 local function pump_cmnd(pos)
 	local leftover = techage.transfer(
-		pos, 
+		pos,
 		"R",  -- outdir
 		"put",  -- topic
 		nil,  -- payload
 		Pipe,  -- Pipe
 		{"techage:ta3_distiller1"})
-	
+
 	-- number of processed oil items
 	return  1 - (tonumber(leftover) or 1)
 end
@@ -86,7 +83,7 @@ end
 local function on_timer(pos)
 	local nvm = techage.get_nvm(pos)
 	nvm.oil_amount = nvm.oil_amount or 0
-	
+
 	-- Power handling
 	if nvm.state == techage.STOPPED then
 		local consumed = power.consume_power(pos, Cable, nil, PWR_NEEDED)
@@ -108,7 +105,7 @@ local function on_timer(pos)
 			return true
 		end
 	end
-	
+
 	-- Oil handling
 	if nvm.state == techage.RUNNING then
 		if nvm.oil_amount >= 1 then
@@ -136,7 +133,7 @@ local function on_timer(pos)
 	end
 	return true
 end
-	
+
 local function after_place_node(pos)
 	local nvm = techage.get_nvm(pos)
 	new_state(pos, nvm, techage.STOPPED)
@@ -173,7 +170,7 @@ minetest.register_node("techage:ta3_reboiler", {
 	after_place_node = after_place_node,
 	after_dig_node = after_dig_node,
 	on_rightclick = on_rightclick,
-	
+
 	paramtype2 = "facedir",
 	on_rotate = screwdriver.disallow,
 	groups = {cracky=2},
@@ -213,7 +210,7 @@ minetest.register_node("techage:ta3_reboiler_on", {
 
 	on_timer = on_timer,
 	on_rightclick = on_rightclick,
-	
+
 	paramtype2 = "facedir",
 	on_rotate = screwdriver.disallow,
 	diggable = false,
@@ -230,7 +227,7 @@ local liquid_def = {
 	put = function(pos, indir, name, amount)
 		local nvm = techage.get_nvm(pos)
 		nvm.oil_amount = nvm.oil_amount or 0
-	
+
 		if nvm.state == techage.STANDBY or nvm.state == techage.RUNNING then
 			if name == "techage:oil_source" and amount > 0 then
 				if nvm.state == techage.STANDBY then
@@ -266,7 +263,7 @@ techage.register_node({"techage:ta3_reboiler", "techage:ta3_reboiler_on"}, {
 	on_node_load = function(pos, node)
 		if node.name == "techage:ta3_reboiler_on" then
 			play_sound(pos)
-		end	
+		end
 		minetest.get_node_timer(pos):start(CYCLE_TIME)
 	end,
 })

--- a/oil/tower.lua
+++ b/oil/tower.lua
@@ -7,14 +7,12 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA3 Oil Tower
 
 ]]--
 
 -- for lazy programmers
-local P = minetest.string_to_pos
-local M = minetest.get_meta
 local S = techage.S
 
 minetest.register_node("techage:oiltower1", {
@@ -198,7 +196,7 @@ minetest.register_node("techage:oil_drillbit2", {
 
 local AssemblyPlan = {
 	-- y-offs, path, facedir-offs, name
-	
+
 	-- level 0
 	{ 0, {0,1}, 0, "techage:oiltower1"},
 	{ 0, {0,3}, 0, "techage:oiltower1"},

--- a/power/formspecs.lua
+++ b/power/formspecs.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Power Formspec Functions
 
 ]]--
@@ -60,9 +60,9 @@ end
 
 local function power_bar(current_power, max_power)
 	local percent, ypos
-		
+
 	current_power = current_power or 0
-	
+
 	if current_power == 0 then
 		percent = 0
 		ypos = 2.8
@@ -75,7 +75,7 @@ local function power_bar(current_power, max_power)
 	current_power = round(current_power)
 	max_power = round(max_power)
 	percent = (percent + 5) / 1.1  -- texture correction
-	
+
 	return "label[0.7,0.4;" .. max_power .. " ku]" ..
 		"image[0,0.5;1,3;" ..
 		"techage_form_level_bg.png^[lowpart:" .. percent ..
@@ -87,7 +87,7 @@ local function storage_bar(current_power, max_power)
 	local percent, ypos
 	max_power = (max_power or 1) / CYCLES_PER_DAY
 	current_power = (current_power or 0) / CYCLES_PER_DAY
-		
+
 	if current_power == 0 then
 		percent = 0
 		ypos = 2.8
@@ -97,9 +97,8 @@ local function storage_bar(current_power, max_power)
 		local offs = 2.4 - (current_power / max_power) * 2.4
 		ypos = 0.4 + in_range(offs, 0.4, 2.4)
 	end
-	current_power = round(current_power)
 	max_power = round(max_power)
-	
+
 	local percent2 = (percent + 5) / 1.1  -- texture correction
 	return "label[0.7,0.4;" .. max_power .. " kud]" ..
 		"image[0,0.5;1,3;"..
@@ -123,7 +122,7 @@ function techage.formspec_charging_bar(pos, x, y, label, data)
 	local charging = 0
 	local percent = 50
 	local ypos = 1.6
-	
+
 	if data then
 		charging = data.provided - data.consumed
 		if charging > 0 then
@@ -135,7 +134,7 @@ function techage.formspec_charging_bar(pos, x, y, label, data)
 		end
 	end
 	ypos = in_range(ypos, 0.4, 2.8)
-	
+
 	return "container[".. x .. "," .. y .. "]" ..
 		"box[0,0;2.3,3.3;#395c74]" ..
 		"label[0.2,0;" .. label .. "]" ..
@@ -146,7 +145,7 @@ end
 
 function techage.formspec_storage_bar(pos, x, y, label, curr_load, max_load)
 	curr_load = curr_load or 0
-	
+
 	return "container[" .. x .. "," .. y .. "]" ..
 		"box[0,0;2.3,3.3;#395c74]" ..
 		"label[0.2,0;" .. label .. "]" ..
@@ -206,21 +205,21 @@ function techage.generator_settings(tier, available)
 			{
 				type = "const",
 				name = "available",
-				label = S("Maximum output [ku]"),      
+				label = S("Maximum output [ku]"),
 				tooltip = S("The maximum power the generator can provide"),
 				value = available,
 			},
 			{
 				type = "output",
 				name = "provided",
-				label = S("Current output [ku]"),      
+				label = S("Current output [ku]"),
 				tooltip = S("The current power the generator provides"),
 			},
 			{
 				type = "dropdown",
 				choices = "0% - 20%,20% - 40%,40% - 60%,60% - 80%,80% - 100%,90% - 100%",
 				name = "termpoint",
-				label = S("Charge termination"),      
+				label = S("Charge termination"),
 				tooltip = S("Range in which the generator reduces its power"),
 				default = "80% - 100%",
 			},
@@ -230,21 +229,21 @@ function techage.generator_settings(tier, available)
 			{
 				type = "const",
 				name = "available",
-				label = S("Maximum output [ku]"),      
+				label = S("Maximum output [ku]"),
 				tooltip = S("The maximum power the generator can provide"),
 				value = available,
 			},
 			{
 				type = "output",
 				name = "provided",
-				label = S("Current output [ku]"),      
+				label = S("Current output [ku]"),
 				tooltip = S("The current power the generator provides"),
 			},
 			{
 				type = "dropdown",
 				choices = "0% - 20%,20% - 40%,40% - 60%,60% - 80%,80% - 100%,90% - 100%",
 				name = "termpoint",
-				label = S("Charge termination"),      
+				label = S("Charge termination"),
 				tooltip = S("Range in which the generator reduces its power"),
 				default = "80% - 100%",
 			},
@@ -255,22 +254,22 @@ end
 
 function techage.evaluate_charge_termination(nvm, meta)
 	local termpoint = meta:get_string("termpoint")
-	if termpoint == "0% - 20%" then 
+	if termpoint == "0% - 20%" then
 		meta:set_string("termpoint1", 0.0)
 		meta:set_string("termpoint2", 0.2)
-	elseif termpoint == "20% - 40%" then 
+	elseif termpoint == "20% - 40%" then
 		meta:set_string("termpoint1", 0.2)
 		meta:set_string("termpoint2", 0.4)
-	elseif termpoint == "40% - 60%" then 
+	elseif termpoint == "40% - 60%" then
 		meta:set_string("termpoint1", 0.4)
 		meta:set_string("termpoint2", 0.6)
-	elseif termpoint == "60% - 80%" then 
+	elseif termpoint == "60% - 80%" then
 		meta:set_string("termpoint1", 0.6)
 		meta:set_string("termpoint2", 0.8)
-	elseif termpoint == "80% - 100%" then 
+	elseif termpoint == "80% - 100%" then
 		meta:set_string("termpoint1", 0.8)
 		meta:set_string("termpoint2", 1.0)
-	elseif termpoint == "90% - 100%" then 
+	elseif termpoint == "90% - 100%" then
 		meta:set_string("termpoint1", 0.9)
 		meta:set_string("termpoint2", 1.0)
 	else
@@ -289,11 +288,11 @@ techage.round = round
 -------------------------------------------------------------------------------
 function techage.formspec_label_bar(pos, x, y, label, max_power, current_power, unit)
 	local percent, ypos
-	
+
 	max_power = max_power or 1
 	unit = unit or "ku"
 	current_power = current_power or 0
-	
+
 	if current_power == 0 then
 		percent = 0
 		ypos = 2.8

--- a/solar/solarcell.lua
+++ b/solar/solarcell.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	TA4 Solar Module and Carriers
-	
+
 ]]--
 
 -- for lazy programmers
@@ -42,14 +42,14 @@ local function light(pos)
 	if minetest.get_node(pos).name ~= "air" then return false end
 	local light = minetest.get_node_light(pos) or 0
 	return light >= (15 - 1)
-end	
-	
+end
+
 -- check if solar module is available and has the correct orientation
 local function is_solar_module(base_pos, pos, side)
 	local pos1 = techage.get_pos(pos, side)
 	if pos1 then
 		local node = techage.get_node_lvm(pos1)
-		if node and node.name == "techage:ta4_solar_module" and 
+		if node and node.name == "techage:ta4_solar_module" and
 						light({x = pos1.x, y = pos1.y + 1, z = pos1.z}) then
 			if side == "L" and node.param2 == M(base_pos):get_int("left_param2") then
 				return true
@@ -79,9 +79,10 @@ local function on_getpower2(pos)
 end
 
 local function after_place_node(pos)
-	M(pos):set_int("temperature", temperature(pos))
-	M(pos):set_int("left_param2", get_param2(pos, "L"))
-	M(pos):set_int("right_param2", get_param2(pos, "R"))
+	local meta = M(pos)
+	meta:set_int("temperature", temperature(pos))
+	meta:set_int("left_param2", get_param2(pos, "L"))
+	meta:set_int("right_param2", get_param2(pos, "R"))
 	Cable:after_place_node(pos)
 end
 
@@ -89,7 +90,7 @@ local function after_dig_node(pos, oldnode)
 	Cable:after_dig_node(pos)
 end
 
-local function tubelib2_on_update2(pos, outdir, tlib2, node) 
+local function tubelib2_on_update2(pos, outdir, tlib2, node)
 	power.update_network(pos, 0, tlib2, node)
 end
 
@@ -146,16 +147,11 @@ minetest.register_node("techage:ta4_solar_carrier", {
 			{-3/8,  5/16, -1/2,  3/8,  7/16, 1/2},
 		},
 	},
-	after_place_node = function(pos)
-		M(pos):set_int("temperature", temperature(pos))
-		M(pos):set_int("left_param2", get_param2(pos, "L"))
-		M(pos):set_int("right_param2", get_param2(pos, "R"))
-	end,
-	
+
 	after_place_node = after_place_node,
 	after_dig_node = after_dig_node,
 	tubelib2_on_update2 = tubelib2_on_update2,
-	
+
 	paramtype = "light",
 	use_texture_alpha = techage.CLIP,
 	paramtype2 = "facedir",
@@ -184,17 +180,11 @@ minetest.register_node("techage:ta4_solar_carrierB", {
 			{-1/8, -6/16, -1/2,  1/8,  8/16, 1/2},
 		},
 	},
-	after_place_node = function(pos)
-		M(pos):set_int("temperature", temperature(pos))
-		M(pos):set_int("left_param2", get_param2(pos, "L"))
-		M(pos):set_int("right_param2", get_param2(pos, "R"))
-		Cable:after_place_node(pos)
-	end,
-	
+
 	after_place_node = after_place_node,
 	after_dig_node = after_dig_node,
 	tubelib2_on_update2 = tubelib2_on_update2,
-	
+
 	paramtype = "light",
 	use_texture_alpha = techage.CLIP,
 	paramtype2 = "facedir",
@@ -223,7 +213,7 @@ minetest.register_node("techage:ta4_solar_carrierT", {
 			{-3/8,  5/16, -1/2,  3/8,  7/16, 1/2},
 		},
 	},
-	
+
 	paramtype = "light",
 	use_texture_alpha = techage.CLIP,
 	paramtype2 = "facedir",

--- a/ta1_watermill/watermill.lua
+++ b/ta1_watermill/watermill.lua
@@ -9,7 +9,7 @@
 	See LICENSE.txt for more information
 
 	TA1 Watermill
-	
+
 ]]--
 
 local M = minetest.get_meta
@@ -24,8 +24,8 @@ local function calc_dir(dir, facedir)
 		return {x = -dir.z, y = dir.y, z = dir.x}
 	end
 	return {x = dir.x, y = dir.y, z = dir.z}
-end	
-	
+end
+
 local function add_node(pos, dir, facedir, node_name)
 	local pos2 = vector.add(pos, calc_dir(dir, facedir))
 	local node = minetest.get_node(pos2)
@@ -45,7 +45,7 @@ end
 local function water_flowing(pos, facedir, tRes)
 	facedir = ((facedir or 0) + 1) % 4
 	local dir =  minetest.facedir_to_dir(facedir)
-	
+
 	local pos2 = vector.add(pos, dir)
 	pos2.y = pos2.y + 1
 	local node = minetest.get_node(pos2)
@@ -53,7 +53,7 @@ local function water_flowing(pos, facedir, tRes)
 		tRes.backward = false
 		return true
 	end
-	
+
 	pos2 = vector.subtract(pos, dir)
 	pos2.y = pos2.y + 1
 	node = minetest.get_node(pos2)
@@ -67,7 +67,7 @@ local function enough_space(pos, facedir)
 	local pos1 = vector.add(pos, calc_dir({x =-1, y =-1, z = 0}, facedir))
 	local pos2 = vector.add(pos, calc_dir({x = 1, y = 1, z = 0}, facedir))
 	local _, nodes = minetest.find_nodes_in_area(pos1, pos2, {"air"})
-	return nodes["air"] and nodes["air"] == 8 
+	return nodes["air"] and nodes["air"] == 8
 end
 
 local function remove_nodes(pos, facedir)
@@ -91,7 +91,7 @@ local function start_wheel(pos, facedir, backward)
 	end
 	local self = obj:get_luaentity()
 	self.facedir = facedir
-	
+
 	add_node(pos, {x = 0, y = 1, z = 0}, facedir, "techage:water_stop")
 	add_node(pos, {x =-1, y = 0, z = 0}, facedir, "techage:water_stop")
 	add_node(pos, {x = 1, y = 0, z = 0}, facedir, "techage:water_stop")
@@ -113,7 +113,7 @@ local function stop_wheel(pos, self)
 		M(pos):set_int("facedir", self.facedir)
 		minetest.get_node_timer(pos):start(2)
 	end
-	
+
 	remove_nodes(pos, self.facedir)
 	self.object:remove()
 end
@@ -121,7 +121,7 @@ end
 local function trigger_consumer(pos, facedir)
 	local outdir = facedir + 1
 	local resp = techage.transfer(
-		pos, 
+		pos,
 		outdir,          -- outdir
 		"trigger",       -- topic
 		nil,             -- payload
@@ -129,8 +129,8 @@ local function trigger_consumer(pos, facedir)
 		nil)             -- valid nodes
 	if not resp then
 		outdir = tubelib2.Turn180Deg[outdir]
-		resp = techage.transfer(
-			pos, 
+		techage.transfer(
+			pos,
 			outdir,          -- outdir
 			"trigger",       -- topic
 			nil,             -- payload
@@ -155,12 +155,12 @@ minetest.register_node("techage:ta1_watermill", {
 		type = "fixed",
 		fixed = {
 			{-1/2, -1/2, -1/2,   1/2, 1/2,  1/2},
-			
+
 			{-4.5/2, -1/2,  0.8/2,   4.5/2, 1/2,  1.0/2},
 			{-4.5/2, -1/2, -1.0/2,   4.5/2, 1/2, -0.8/2},
 			{-3.8/2, -1/2,  2.1/2,   3.8/2, 1/2,  2.3/2},
 			{-3.8/2, -1/2, -2.3/2,   3.8/2, 1/2, -2.1/2},
-		                                    
+
 			{ 0.8/2, -1/2, -4.5/2,   1.0/2, 1/2,  4.5/2},
 			{-1.0/2, -1/2, -4.5/2,  -0.8/2, 1/2,  4.5/2},
 			{ 2.1/2, -1/2, -3.8/2,   2.3/2, 1/2,  3.8/2},
@@ -170,7 +170,7 @@ minetest.register_node("techage:ta1_watermill", {
 	on_rightclick = function(pos, node, clicker)
 		start_wheel(pos, M(pos):get_int("facedir"))
 	end,
-	
+
 	on_timer = function(pos, elapsed)
 		local tRes = {}
 		if water_flowing(pos, M(pos):get_int("facedir"), tRes) then
@@ -178,7 +178,7 @@ minetest.register_node("techage:ta1_watermill", {
 		end
 		return true
 	end,
-	
+
 	paramtype2 = "facedir",
 	paramtype = "light",
 	use_texture_alpha = techage.CLIP,
@@ -208,19 +208,19 @@ minetest.register_node("techage:ta1_watermill_inv", {
 		type = "fixed",
 		fixed = {
 			{-1/4, -1/4, -1/4,   1/4, 1/4,  1/4},
-			
+
 			{-4.5/4,  0.8/4, -1/4,   4.5/4,  1.0/4, 1/4},
 			{-4.5/4, -1.0/4, -1/4,   4.5/4, -0.8/4, 1/4},
 			{-3.8/4,  2.1/4, -1/4,   3.8/4,  2.3/4, 1/4},
 			{-3.8/4, -2.3/4, -1/4,   3.8/4, -2.1/4, 1/4},
-		                                            
+
 			{ 0.8/4, -4.5/4, -1/4,   1.0/4,  4.5/4, 1/4},
 			{-1.0/4, -4.5/4, -1/4,  -0.8/4,  4.5/4, 1/4},
 			{ 2.1/4, -3.8/4, -1/4,   2.3/4,  3.8/4, 1/4},
 			{-2.3/4, -3.8/4, -1/4,  -2.1/4,  3.8/4, 1/4},
 		},
 	},
-	
+
 	after_place_node = function(pos, placer)
 		local node = minetest.get_node(pos)
 		M(pos):set_int("facedir", node.param2)
@@ -236,7 +236,7 @@ minetest.register_node("techage:ta1_watermill_inv", {
 			return true
 		end
 	end,
-	
+
 	paramtype2 = "facedir",
 	node_placement_prediction = "",
 	diggable = false,
@@ -246,7 +246,7 @@ techage.register_node({"techage:ta1_watermill"}, {
 	on_node_load = function(pos, node)
 		minetest.get_node_timer(pos):start(2)
 	end,
-})	
+})
 
 
 minetest.register_entity("techage:ta1_watermill_entity", {
@@ -260,10 +260,10 @@ minetest.register_entity("techage:ta1_watermill_entity", {
 		automatic_rotate = -math.pi * 0.2,
 		pointable = false,
 	},
-	
+
 	on_step = function(self, dtime)
 		self.dtime = (self.dtime or 0) + dtime
-		
+
 		if self.dtime > 2 then
 			self.dtime = 0
 			local pos = vector.round(self.object:get_pos())
@@ -275,7 +275,7 @@ minetest.register_entity("techage:ta1_watermill_entity", {
 			max_hear_distance = 10}, true)
 		end
 	end,
-	
+
 	on_rightclick = function(self, clicker)
 		local pos = vector.round(self.object:get_pos())
 		stop_wheel(pos, self)
@@ -284,7 +284,7 @@ minetest.register_entity("techage:ta1_watermill_entity", {
 	on_activate = function(self, staticdata)
 		self.facedir = tonumber(staticdata) or 0
 	end,
-	
+
 	get_staticdata = function(self)
 		return self.facedir
 	end,
@@ -295,7 +295,7 @@ minetest.register_node("techage:water_stop", {
 	drawtype = "glasslike_framed_optional",
 	tiles = {"techage_invisible.png"},
 	inventory_image = 'techage_invisible_inv.png',
-	
+
 	use_texture_alpha = "blend",
 	paramtype = "light",
 	walkable = false,

--- a/ta4_power/electricmeter.lua
+++ b/ta4_power/electricmeter.lua
@@ -7,13 +7,12 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA4 Electric Meter (to separate networks)
 
 ]]--
 
 -- for lazy programmers
-local P2S = minetest.pos_to_string
 local M = minetest.get_meta
 local S = techage.S
 
@@ -28,7 +27,7 @@ local control = networks.control
 local function formspec(self, pos, nvm, power)
 	local units = (nvm.units or 0) / techage.CYCLES_PER_DAY
 	power = power or 0
-	
+
 	return "size[5,4]" ..
 		default.gui_bg ..
 		default.gui_bg_img ..
@@ -81,7 +80,7 @@ local function node_timer(pos, elapsed)
 	if techage.is_activeformspec(pos) then
 		M(pos):set_string("formspec", formspec(State, pos, nvm, nvm.moved))
 	end
-	return true		
+	return true
 end
 
 local function on_rightclick(pos, node, clicker)
@@ -109,7 +108,7 @@ end
 
 local function after_dig_node(pos, oldnode, oldmetadata, digger)
 	local outdir = tonumber(oldmetadata.fields.outdir or 0)
-	Cable:after_dig_node(pos, {outdir, networks.Flip[outdir]})        
+	Cable:after_dig_node(pos, {outdir, networks.Flip[outdir]})
 	techage.del_mem(pos)
 end
 
@@ -175,7 +174,7 @@ control.register_nodes({"techage:ta4_electricmeter"}, {
 					running = techage.is_running(nvm) or false,
 					available = PWR_PERF,
 					provided = nvm.moved or 0,
-					termpoint = "-", 
+					termpoint = "-",
 				}
 			end
 			return false

--- a/ta4_power/laser.lua
+++ b/ta4_power/laser.lua
@@ -7,14 +7,13 @@
 
 	GPL v3
 	See LICENSE.txt for more information
-	
-	TA4 Laser beam emitter and receiver 
-	
+
+	TA4 Laser beam emitter and receiver
+
 ]]--
 
 -- for lazy programmers
 local P2S = function(pos) if pos then return minetest.pos_to_string(pos) end end
-local S2P = minetest.string_to_pos
 local M = minetest.get_meta
 local S = techage.S
 
@@ -39,15 +38,15 @@ minetest.register_node("techage:ta4_laser_emitter", {
 		Cable:after_place_node(pos, {tube_dir})
 		local number = techage.add_node(pos, "techage:ta4_laser_emitter")
 		M(pos):set_string("node_number", number)
-		local res, pos1, pos2 = techage.renew_laser(pos, true)
+		local _, pos1, pos2 = techage.renew_laser(pos, true)
 		if pos1 then
 			local node = techage.get_node_lvm(pos2)
 			if node.name == "techage:ta4_laser_receiver" then
 				Cable:pairing(pos2, "laser")
 				Cable:pairing(pos, "laser")
 			else
-				minetest.chat_send_player(placer:get_player_name(), 
-					S("Valid destination positions:") .. " " .. 
+				minetest.chat_send_player(placer:get_player_name(),
+					S("Valid destination positions:") .. " " ..
 					P2S(pos1) .. " " .. S("to") .. " " .. P2S(pos2))
 			end
 		else
@@ -82,14 +81,14 @@ minetest.register_node("techage:ta4_laser_emitter", {
 		end
 		return true
 	end,
-	
+
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		techage.del_laser(pos)
 		Cable:stop_pairing(pos, oldmetadata, "")
 		local tube_dir = tonumber(oldmetadata.fields.tube_dir or 0)
 		Cable:after_dig_node(pos, {tube_dir})
 	end,
-	
+
 	paramtype2 = "facedir",
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,
@@ -119,7 +118,7 @@ minetest.register_node("techage:ta4_laser_receiver", {
 		local tube_dir = tonumber(oldmetadata.fields.tube_dir or 0)
 		Cable:after_dig_node(pos, {tube_dir})
 	end,
-	
+
 	paramtype2 = "facedir",
 	groups = {choppy=2, cracky=2, crumbly=2},
 	is_ground_content = false,

--- a/ta4_power/transformer.lua
+++ b/ta4_power/transformer.lua
@@ -7,13 +7,12 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	TA4 Isolation Transformer (to separate networks)
 
 ]]--
 
 -- for lazy programmers
-local P2S = minetest.pos_to_string
 local M = minetest.get_meta
 local S = techage.S
 
@@ -79,7 +78,7 @@ local function node_timer(pos, elapsed)
 	if techage.is_activeformspec(pos) then
 		M(pos):set_string("formspec", formspec(State, pos, nvm, data))
 	end
-	return true		
+	return true
 end
 
 local function on_rightclick(pos, node, clicker)
@@ -107,7 +106,7 @@ end
 
 local function after_dig_node(pos, oldnode, oldmetadata, digger)
 	local outdir = tonumber(oldmetadata.fields.outdir or 0)
-	Cable:after_dig_node(pos, {outdir, networks.Flip[outdir]})        
+	Cable:after_dig_node(pos, {outdir, networks.Flip[outdir]})
 	techage.del_mem(pos)
 end
 
@@ -165,7 +164,7 @@ control.register_nodes({"techage:ta4_transformer"}, {
 					running = techage.is_running(nvm) or false,
 					available = PWR_PERF,
 					provided = nvm.moved or 0,
-					termpoint = "-", 
+					termpoint = "-",
 				}
 			end
 			return false

--- a/tools/trowel.lua
+++ b/tools/trowel.lua
@@ -7,7 +7,7 @@
 
 	AGPL v3
 	See LICENSE.txt for more information
-	
+
 	Trowel tool to hide/open cable/pipe/tube nodes
 
 ]]--
@@ -25,7 +25,7 @@ local function replace_node(itemstack, placer, pointed_thing)
 			return
 		end
 		local node = minetest.get_node(pos)
-		local res = false
+		local res
 		if minetest.get_item_group(node.name, "techage_trowel") == 1 then
 			res = networks.hide_node(pos, node, placer)
 		elseif networks.hidden_name(pos) or M(pos):get_string("techage_hidden_nodename") ~= "" then
@@ -36,7 +36,7 @@ local function replace_node(itemstack, placer, pointed_thing)
 		end
 		if res then
 			minetest.sound_play("default_dig_snappy", {
-				pos = pos, 
+				pos = pos,
 				gain = 1,
 				max_hear_distance = 5})
 		elseif placer and placer.get_player_name then

--- a/wind_turbine/signallamp.lua
+++ b/wind_turbine/signallamp.lua
@@ -8,28 +8,12 @@
 	AGPL v3
 	See LICENSE.txt for more information
 
-	Colored Signal Lamp (requires unifieddyes)
-	
+	Wind Turbine Signal Lamp
+
 ]]--
 
 -- for lazy programmers
-local M = minetest.get_meta
 local S = techage.S
-
-local logic = techage.logic
-
-local COLORED = minetest.get_modpath("unifieddyes") and minetest.global_exists("unifieddyes")
-
-
-local function switch_on(pos, node)
-	node.name = "techage:signal_lamp_on"
-	minetest.swap_node(pos, node)
-end	
-
-local function switch_off(pos, node)
-	node.name = "techage:signal_lamp_off"
-	minetest.swap_node(pos, node)
-end	
 
 minetest.register_node("techage:rotor_signal_lamp_off", {
 	description = S("TA4 Wind Turbine Signal Lamp"),
@@ -76,7 +60,7 @@ minetest.register_node("techage:rotor_signal_lamp_on", {
 		minetest.swap_node(pos, {name = "techage:rotor_signal_lamp_off"})
 		return true
 	end,
-	
+
 	paramtype = "light",
 	use_texture_alpha = techage.CLIP,
 	light_source = 8,


### PR DESCRIPTION
luacheck is a linter and static analyzer for Lua code. It is helpful to detect accidental programming mistakes.
Most of the changes are unused variable removals.
There are also a few bug fixes, for example the missing basic_dump function used by techage.mydump and the duplicate ta4_terminal entry in the docs, where one of them was the Luacontroller Terminal.