### PR TITLE
(TA4 reactor) fix order of tank and silo in build plan

### DIFF
--- a/doc/plans.lua
+++ b/doc/plans.lua
@@ -354,8 +354,8 @@ techage.ConstructionPlans["ta4_reactor"] = {
 	{false, false, false, false, PN000, PIPEH, PIPEH, PN270, false, false, false},
 	{false, false, false, false, PIPEV, false, false, FILLR, false, false, false},
 	{false, false, false, false, PIPEV, false, false, REACT, false, false, false},
-	{false, false, false, false, PIPEV, false, false, STAND, PIPEH, PIPEH, SILO},
-	{false, TANK3, PIPEH, PIPEH, DOSER, PN270, false, RBASE, PIPEH, PIPEH, TANK3},
+	{false, false, false, false, PIPEV, false, false, STAND, PIPEH, PIPEH, TANK3},
+	{false, TANK3, PIPEH, PIPEH, DOSER, PN270, false, RBASE, PIPEH, PIPEH, SILO},
 	{false, SILO,  PIPEH, PIPEH, PIPEH, PN180, false, false, false, false, false},
 }
 


### PR DESCRIPTION
Reported on my server

_Report by Preservoir:
Error in TA4 Chemical Reactor tutorial. Plan says output silo must be up (against blue stand) and the output tank must be down (against concrete stand). In fact in game - vice versa._