### PR TITLE
register mvps stopper for complex techage nodes

### DIFF
--- a/basis/command.lua
+++ b/basis/command.lua
@@ -16,6 +16,7 @@
 local S = function(pos) if pos then return minetest.pos_to_string(pos) end end
 --local P = minetest.string_to_pos
 --local M = minetest.get_meta
+local has_mesecons = minetest.get_modpath("mesecons_mvps") 
 
 local NodeInfoCache = {}
 local NumbersToBeRecycled = {}
@@ -316,6 +317,13 @@ function techage.register_node(names, node_definition)
 	-- register LBM
 	if node_definition.on_node_load then
 		register_lbm(names[1], names)
+	end
+
+	-- register mvps stopper
+	if has_mesecons then
+		for _, name in ipairs(names) do
+			mesecon.register_mvps_stopper(name)
+		end
 	end
 end
 

--- a/basis/command.lua
+++ b/basis/command.lua
@@ -16,7 +16,7 @@
 local S = function(pos) if pos then return minetest.pos_to_string(pos) end end
 --local P = minetest.string_to_pos
 --local M = minetest.get_meta
-local has_mesecons = minetest.get_modpath("mesecons_mvps") 
+local has_mesecons = minetest.global_exists("mesecons_mvps")
 
 local NodeInfoCache = {}
 local NumbersToBeRecycled = {}

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = techage
 depends = default,doors,flowers,tubelib2,networks,basic_materials,bucket,stairs,screwdriver,minecart,lcdlib,safer_lua
-optional_depends = unified_inventory,wielded_light,unifieddyes,moreores,ethereal,mesecons,mesecons_materials,digtron,bakedclay,moreblocks,i3,creative,craftguide
+optional_depends = unified_inventory,wielded_light,unifieddyes,moreores,ethereal,mesecons,mesecons_materials,mesecons_mvps,digtron,bakedclay,moreblocks,i3,creative,craftguide
 description = Techage, go through 5 tech ages in search of wealth and power!


### PR DESCRIPTION
"fixes" problems with mesecons mvps by registering stoppers for all "complex" nodes with techage support

> Techage blocks store information outside of the block. This is for performance reasons. If you move, place, or remove blocks with any tool, at best, only the information is lost. In the worst case, the server crashes. (readme.md)

