### PR TITLE
add an option to disable stair aliases

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -57,6 +57,7 @@ techage.ore_rarity = tonumber(minetest.settings:get("techage_ore_rarity")) or 1
 techage.modified_recipes_enabled = minetest.settings:get_bool("techage_modified_recipes_enabled") ~= false
 techage.collider_min_depth = tonumber(minetest.settings:get("techage_collider_min_depth")) or -28
 techage.recipe_checker_enabled = minetest.settings:get_bool("techage_recipe_checker_enabled") ~= false
+techage.stair_aliases_enabled = minetest.settings:get_bool("techage_stair_aliases_enabled") ~= false
 
 -- allow to load marshal and sqlite3
 techage.IE = minetest.request_insecure_environment()

--- a/items/moreblocks.lua
+++ b/items/moreblocks.lua
@@ -68,9 +68,11 @@ if(minetest.get_modpath("moreblocks")) then
 			ndef.sunlight_propagates = true
 			ndef.groups.not_in_creative_inventory = 1
 			stairsplus:register_all("techage", subname, name, ndef)
-			register_alias(subname)
+			if techage.stair_aliases_enabled then
+				register_alias(subname)
+			end
 		end
-    end
+	end
 else
     for _,name in ipairs(NodeNames) do
 		local ndef = minetest.registered_nodes[name]
@@ -86,7 +88,9 @@ else
 				ndef.sound,
 				false
 			)
-			register_alias(subname)
+			if techage.stair_aliases_enabled then
+				register_alias(subname)
+			end
 		end
 	end
 end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -41,3 +41,6 @@ techage_expoint_rate_in_min (average waiting time for one expoint) int 60
 
 # For testing purpuses only
 techage_recipe_checker_enabled (test techage recipes) bool false
+
+# Enables stair aliases (to prevent unknown nodes)
+techage_stair_aliases_enabled (Enable stair aliases) bool false


### PR DESCRIPTION
aliases remain enabled by default

add this to your minetest.conf to disable the aliases
`techage_stair_aliases_enabled = false`