### PR TITLE
fix unknown item drops

### DIFF
--- a/items/moreblocks.lua
+++ b/items/moreblocks.lua
@@ -53,8 +53,8 @@ local NodeNames = {
 
 	"techage:basalt_glass",
 	"techage:basalt_glass2",
-	"techage:bauxite_stone",
 	"techage:bauxite_cobble",
+	"techage:bauxite_stone",
 
 	"techage:cement_block",
 }
@@ -64,6 +64,9 @@ if(minetest.get_modpath("moreblocks")) then
 		local ndef = minetest.registered_nodes[name]
 		if ndef then
 			ndef = table.copy(ndef)
+			if ndef.drop then -- this fixes https://github.com/fluxionary/minetest-moreblocks/issues/19
+				ndef.drop = nil
+			end
 			local subname = string.split(name, ":")[2]
 			ndef.sunlight_propagates = true
 			ndef.groups.not_in_creative_inventory = 1


### PR DESCRIPTION
Don't ask me why this works, but it works :smile: 
This fixes https://github.com/fluxionary/minetest-moreblocks/issues/19 and solves our PM discussion about that.
Behavior with moreblocks 3.0: digging a basalt stone stair -> drop: basalt cobble stair
Behavior with moreblocks 2.0: digging a basalt stone stair -> drop: basalt stone stair
Previously, an unknown node was dropped on both variants.