### PR TITLE
fix forceload formspec receiver

### DIFF
--- a/basic_machines/forceload.lua
+++ b/basic_machines/forceload.lua
@@ -169,7 +169,7 @@ local function on_rightclick(pos, node, clicker, itemstack, pointed_thing)
 	if name == owner or	minetest.check_player_privs(name, "server") then
 		local s = formspec(owner)
 		if s then
-			minetest.show_formspec(owner, "techage:forceload", s)
+			minetest.show_formspec(name, "techage:forceload", s)
 		end
 	end
 end


### PR DESCRIPTION
old behavior:
player1 places a forceload block
player2 right-clicks the forceload block - nothing happens
player2 right-clicks the forceload block while player1 is offline - nothing happens
admin1 right-clicks the forceload block - **the formspec appears to player1** -- changed
admin1 right-clicks the forceload block while player1 is offline - nothing happens
player1 right-clicks the forceload block - the formspec appears to player1

new behavior:
player1 places a forceload block
player2 right-clicks the forceload block - nothing happens
player2 right-clicks the forceload block while player1 is offline - nothing happens
admin1 right-clicks the forceload block - **the formspec appears for admin1** -- changed
admin1 right-clicks the forceload block while player1 is offline - nothing happens
player1 right-clicks the forceload block - the formspec appears to player1