### PR TITLE
Add optional dependency on farming mod

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = techage
 depends = default,doors,flowers,tubelib2,networks,basic_materials,bucket,stairs,screwdriver,minecart,lcdlib,safer_lua
-optional_depends = unified_inventory,wielded_light,unifieddyes,moreores,ethereal,mesecons,mesecons_materials,mesecons_mvps,digtron,bakedclay,moreblocks,i3,creative,craftguide
+optional_depends = unified_inventory,wielded_light,unifieddyes,moreores,ethereal,mesecons,mesecons_materials,mesecons_mvps,digtron,bakedclay,moreblocks,i3,creative,craftguide,farming
 description = Techage, go through 5 tech ages in search of wealth and power!


### PR DESCRIPTION
While trying out techage_modpack, I noticed that the TA1 mill doesn't have any recipes registered. I could eventually track it down to the following:
- At load time, if techage gets loaded before farming, the registration for the wheat recipes (in the mill) is skipped
- Changing the global_exists() to a get_modpack() doesn't remedy the issue as add_grinder_recipe() checks for item existence Soft-depending on farming remedies the issue and the mill works normally.