### PR TITLE
log position of coroutine errors

### DIFF
--- a/basic_machines/quarry.lua
+++ b/basic_machines/quarry.lua
@@ -243,7 +243,7 @@ local function keep_running(pos, elapsed)
 	local crd = CRD(pos)
 	local _, err = coroutine.resume(mem.co, pos, crd, nvm)
 	if err then
-		minetest.log("error", "[TA4 Quarry Coroutine Error]" .. err)
+		minetest.log("error", "[TA4 Quarry Coroutine Error] at pos " .. minetest.pos_to_string(pos) .. " " .. err)
 	end
 
 	if techage.is_activeformspec(pos) then


### PR DESCRIPTION
looks like this now
```lua
2023-07-15 13:03:08: ERROR[Server]: [TA4 Quarry Coroutine Error] at pos (5996,13,601) /home/nik/mt-server/bin/../mods/signs_bot/basis.lua:189: attempt to index local 'inv' (a nil value)
2023-07-15 13:03:12: ERROR[Server]: [TA4 Quarry Coroutine Error] at pos (5996,13,601) cannot resume dead coroutine
```