### PR TITLE
Text adjustment for 2x 4x controls

### DIFF
--- a/logic/button_2x.lua
+++ b/logic/button_2x.lua
@@ -88,6 +88,14 @@ local WRENCH_MENU = {
 	},
 	{
 		type = "dropdown",
+		choices = "left,center",
+		name = "text_align",
+		label = S("Text align"),
+		tooltip = S("Label text alignment"),
+		default = "1",
+	},
+	{
+		type = "dropdown",
 		choices = "private,protected,public",
 		name = "access",
 		label = S("Access"),
@@ -117,7 +125,8 @@ local function button_update(pos, objref)
 	local nvm = techage.get_nvm(pos)
 	nvm.button = nvm.button or {}
 	local tbl = {" ", " ", meta:get_string("label1"), " ",  meta:get_string("label2")}
-	local text = "<      " .. table.concat(tbl, "\n<      ")
+	local txa = meta:get_string("text_align") == "center" and "\t" or ""
+	local text = txa .. "      " .. table.concat(tbl, "\n" .. txa .. "      ")
 	local texture = lcdlib.make_multiline_texture("default", text, 96, 96, 7, "top", "#000", 6)
 
 	if nvm.button[1] then

--- a/logic/button_4x.lua
+++ b/logic/button_4x.lua
@@ -136,6 +136,14 @@ local WRENCH_MENU = {
 	},
 	{
 		type = "dropdown",
+		choices = "left,center",
+		name = "text_align",
+		label = S("Text align"),
+		tooltip = S("Label text alignment"),
+		default = "1",
+	},
+	{
+		type = "dropdown",
 		choices = "private,protected,public",
 		name = "access",
 		label = S("Access"),
@@ -165,7 +173,8 @@ local function button_update(pos, objref)
 	local nvm = techage.get_nvm(pos)
 	nvm.button = nvm.button or {}
 	local tbl = {meta:get_string("label1"), " ",  meta:get_string("label2"), " ", meta:get_string("label3"), " ", meta:get_string("label4")}
-	local text = "<      " .. table.concat(tbl, "\n<      ")
+	local txa = meta:get_string("text_align") == "center" and "\t" or ""
+	local text = txa .. "      " .. table.concat(tbl, "\n" .. txa .. "      ")
 	local texture = lcdlib.make_multiline_texture("default", text, 96, 96, 7, "top", "#000", 6)
 
 	if nvm.button[1] then

--- a/logic/signallamp_2x.lua
+++ b/logic/signallamp_2x.lua
@@ -36,6 +36,14 @@ local WRENCH_MENU = {
 		tooltip = S("Label for the lamp"),
 		default = "2",
 	},
+	{
+		type = "dropdown",
+		choices = "left,center",
+		name = "text_align",
+		label = S("Text align"),
+		tooltip = S("Label text alignment"),
+		default = "1",
+	},
 }
 
 local function lamp_update(pos, objref)
@@ -44,7 +52,8 @@ local function lamp_update(pos, objref)
 	local nvm = techage.get_nvm(pos)
 	nvm.lamp = nvm.lamp or {}
 	local tbl = {" ", " ", meta:get_string("label1"), " ",  meta:get_string("label2")}
-	local text = "<      " .. table.concat(tbl, "\n<      ")
+	local txa = meta:get_string("text_align") == "center" and "\t" or ""
+	local text = txa .. "      " .. table.concat(tbl, "\n" .. txa .. "      ")
 	local texture = lcdlib.make_multiline_texture("default", text, 96, 96, 7, "top", "#000", 6)
 
 	if nvm.lamp[1] == RED then

--- a/logic/signallamp_4x.lua
+++ b/logic/signallamp_4x.lua
@@ -50,6 +50,14 @@ local WRENCH_MENU = {
 		tooltip = S("Label for the lamp"),
 		default = "4",
 	},
+	{
+		type = "dropdown",
+		choices = "left,center",
+		name = "text_align",
+		label = S("Text align"),
+		tooltip = S("Label text alignment"),
+		default = "1",
+	},
 }
 
 local function lamp_update(pos, objref)
@@ -58,7 +66,8 @@ local function lamp_update(pos, objref)
 	local nvm = techage.get_nvm(pos)
 	nvm.lamp = nvm.lamp or {}
 	local tbl = {meta:get_string("label1"), " ",  meta:get_string("label2"), " ", meta:get_string("label3"), " ", meta:get_string("label4")}
-	local text = "<      " .. table.concat(tbl, "\n<      ")
+	local txa = meta:get_string("text_align") == "center" and "\t" or ""
+	local text = txa .. "      " .. table.concat(tbl, "\n" .. txa .. "      ")
 	local texture = lcdlib.make_multiline_texture("default", text, 96, 96, 7, "top", "#000", 6)
 
 	if nvm.lamp[1] == RED then


### PR DESCRIPTION
Hello JoSto!

This patch addresses issue reported on TechAge forum. It makes TA4 2x/4x Buttons and Lamps display text labels correctly again. In this solution I added a setting so user can choose if labels are centered or left-aligned. Alignment is compatible with latest lcdlib that changed special character from '<' to TAB.

Cheers
Micu