### PR TITLE
Fix converter stores mesecon signals

### DIFF
--- a/logic/mesecons_converter.lua
+++ b/logic/mesecons_converter.lua
@@ -143,7 +143,7 @@ minetest.register_node("techage:ta3_mesecons_converter_on", {
 
 	mesecons = {
 		receptor = {
-			state = mesecon.state.on,
+			state = mesecon.state.off,
 			rules = mesecon.rules.default,
 		},
 		effector = {
@@ -164,7 +164,7 @@ minetest.register_node("techage:ta3_mesecons_converter_on", {
 	paramtype = "light",
 	light_source = 5,
 	paramtype2 = "facedir",
-	groups = {choppy=2, cracky=2, crumbly=2},
+	groups = {choppy=2, cracky=2, crumbly=2, not_in_creative_inventory=1},
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),
 	drop = "techage:ta3_mesecons_converter",


### PR DESCRIPTION
- Fixes that mesecons coverter keeps on while no "energy source" is the network anymore
- Fixes that mesecons converter_on is visible in the craftguide

https://github.com/Archtec-io/bugtracker/issues/121