### PR TITLE
Remove wearing screwdriver

### DIFF
--- a/tools/screwdriver.lua
+++ b/tools/screwdriver.lua
@@ -127,9 +127,6 @@ local function on_place(itemstack, user, pointed_thing)
 			return screwdriver.handler(itemstack, user, pointed_thing, screwdriver.ROTATE_AXIS, USES)
 		end
 
-		if not minetest.is_creative_enabled(player_name) then
-			itemstack:add_wear(65535 / (USES - 1))
-		end
 	end
 	return itemstack
 end


### PR DESCRIPTION
The screwdriver in the game does not exist to make the game less casual, wearing for the screwdriver is the worst idea you could come up with. If a player wants to unwrap an item and doesn't want to do it manually, do you think he would want to craft 100 non-stacking screwdrivers?

I hope there will be support for this commit. All tools that compensate for the shortcomings of the game and should generally be built into the game should not have wear and tear.