### PR TITLE
Adds a chat command and extra column to forceload formspec to verify force load state

### DIFF
--- a/basic_machines/forceload.lua
+++ b/basic_machines/forceload.lua
@@ -114,24 +114,21 @@ local function formspec(name)
 	if player then
 		local lPos = get_pos_list(player)
 		local tRes = {}
-	tRes[#tRes+1] = "#"
-	tRes[#tRes+1] = S("Block at pos")
-	tRes[#tRes+1] = S("Area from")
-	tRes[#tRes+1] = S("Area to")
-	for idx,pos in ipairs(lPos) do
+		for idx,pos in ipairs(lPos) do
 			local pos1, pos2 = calc_area(pos)
 			tRes[#tRes+1] = idx
-			tRes[#tRes+1] = minetest.formspec_escape(P2S(pos))
 			tRes[#tRes+1] = minetest.formspec_escape(P2S(pos1))
+			tRes[#tRes+1] = "to"
 			tRes[#tRes+1] = minetest.formspec_escape(P2S(pos2))
+			tRes[#tRes+1] = minetest.forceload_block(pos, true) and 'Loaded' or 'Unloaded'
 		end
-		return "size[9,9]"..
+		return "size[7,9]"..
 			default.gui_bg..
 			default.gui_bg_img..
 			default.gui_slots..
 			"label[0,0;"..S("List of your Forceload Blocks:").."]"..
-			"tablecolumns[text,width=1.8;text,width=12;text,width=12;text,width=12]"..
-			"table[0,0.6;8.8,8.4;output;"..table.concat(tRes, ",")..";1]"
+			"tablecolumns[text,width=1.2;text,width=12;text,width=1.6;text,width=12;text,width=12]"..
+			"table[0,0.6;6.8,8.4;output;"..table.concat(tRes, ",")..";1]"
 	end
 end
 
@@ -307,6 +304,24 @@ minetest.register_chatcommand("forceload", {
 			local pos = player:get_pos()
 			pos = vector.round(pos)
 			show_flbs(pos, name, 64)
+		end
+	end,
+})
+
+minetest.register_chatcommand("forceload_verify", {
+	params = "",
+	description = "Checks each forceload block and returns a count of active/placed blocks",
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		if player then
+			local loaded = {}
+			local wanted = get_pos_list(player)
+			for _,pos in ipairs(wanted) do
+				if minetest.forceload_block(pos, true) then
+					loaded[#loaded+1] = pos
+				end
+			end
+			chat(name, "Found "..#loaded.." out of ".. #wanted .. " force loads")
 		end
 	end,
 })


### PR DESCRIPTION
Creates a `/forceload_verify` chat command that will show a count of force load blocks that appear to be successfully force loaded compared with the total number of placed forceload blocks and adds a column to the formspec to show whether or not each block is successfully loaded. This is related to Issue #160 