### PR TITLE
Add or minetest.registered_nodes[name] to Silo powder check.

### DIFF
--- a/liquids/silo.lua
+++ b/liquids/silo.lua
@@ -3,7 +3,7 @@
 	TechAge
 	=======
 
-	Copyright (C) 2019-2022 Joachim Stolberg
+	Copyright (C) 2019-2024 Joachim Stolberg
 
 	AGPL v3
 	See LICENSE.txt for more information
@@ -128,7 +128,7 @@ local tLiquid = {
 	put = function(pos, indir, name, amount)
 		-- check if it is powder
 		local nvm = techage.get_nvm(pos)
-		local ndef = minetest.registered_craftitems[name] or {}
+		local ndef = minetest.registered_craftitems[name] or minetest.registered_nodes[name] or {}
 		if ndef.groups and ndef.groups.powder == 1 then
 			local inv = M(pos):get_inventory()
 			local stack = ItemStack(name.." "..amount)


### PR DESCRIPTION
This pull request adds “or minetest.registered_nodes[name]” to the Silo powder check in line 131, permitting items included in the powder group, but registered as nodes, to be stored in the Silo. This improves interoperability with other mods by expanding the scope of items that can be stored, while still limiting it to the powder group.

It should be noted the powder check in lines 31-33 are not affected by this pull request.

I release this code under the terms of AGPL v3, and transfer copyright to Joachim Stolberg.