### PR TITLE
Water to Salt + River Water Reactor Recipe

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3,7 +3,7 @@
 	TechAge
 	=======
 
-	Copyright (C) 2019-2023 Joachim Stolberg
+	Copyright (C) 2019-2024 Joachim Stolberg
 
 	AGPL v3
 	See LICENSE.txt for more information
@@ -394,6 +394,7 @@ dofile(MP.."/items/cracking.lua")
 dofile(MP.."/items/ceramic.lua")
 dofile(MP.."/items/basalt.lua")
 dofile(MP.."/items/moreblocks.lua")
+dofile(MP.."/items/salt.lua")
 
 -- Carts
 dofile(MP.."/carts/tank_cart.lua")

--- a/items/salt.lua
+++ b/items/salt.lua
@@ -1,0 +1,44 @@
+--[[
+
+	TechAge
+	=======
+
+	Copyright (C) 2024 Joachim Stolberg
+
+	AGPL v3
+	See LICENSE.txt for more information
+
+	Salt
+
+]]--
+
+local S = techage.S
+
+
+--Detects if the salt node is registered.
+minetest.register_on_mods_loaded(function()
+    if minetest.registered_nodes["farming:salt"] then
+		--Adds salt to powder group to ensure reactor and silo will accept it
+		local def = minetest.registered_nodes["farming:salt"]
+		local groups = table.copy(def.groups)
+		groups.powder = 1
+		minetest.override_item("farming:salt", { groups=groups })
+
+		--Add the water -> salt & river water recipe.
+		techage.recipes.add("ta4_doser", {
+			output = "farming:salt 1",
+			waste = "techage:river_water 1",
+			input = {
+				"techage:water 1",
+				}
+		})
+     	else
+     		-- Creates a water -> River Water recipe in absense of the farming:salt node.
+     		techage.recipes.add("ta4_doser", {
+			output = "techage:river_water 1",
+			input = {
+				"techage:water 1",
+				}
+		})
+    end
+end)


### PR DESCRIPTION
This pull requests adds a Water → River Water reactor recipe. 

If it detects a 'farming:salt' node (as found in the Farming Redo mod) it will add the salt node to the powder group, allowing it to be stored in silos, and changes the recipe to Water → Salt with River Water as a waste product.

It should be noted that issue #174 must be resolved to implement this pull request, as otherwise nodes cannot be loaded into the silo, even if they are in the powder group. This pull request was tested with pull request #174 implemented. Using another solution to issue #174 may require updates to the pull request.

I release this code under the terms of AGPL v3, and transfer copyright to Joachim Stolberg.