### PR TITLE
Add replacement to Electric Meter recipe

### DIFF
--- a/ta4_power/electricmeter.lua
+++ b/ta4_power/electricmeter.lua
@@ -251,4 +251,5 @@ minetest.register_craft({
 		{"techage:electric_cableS", "basic_materials:gold_wire", "techage:electric_cableS"},
 		{"default:steel_ingot", "techage:ta4_wlanchip", "default:steel_ingot"},
 	},
+	replacements = { {"basic_materials:gold_wire", "basic_materials:empty_spool"}, },
 })


### PR DESCRIPTION
Adds a replacement value to the electric meter recipe so as to return an empty spool after crafting an Electric Meter.

### **To Do**

Code is ready for review.

### **How to Test**
Replace electricmeter.lua with updated version. Start game. Craft an Electric Meter. Observe one empty spool is returned for each Electric Meter Crafted.