### PR TITLE
Fixes gravel ore probability when using the everness mod

### DIFF
--- a/basis/gravel_lib.lua
+++ b/basis/gravel_lib.lua
@@ -32,7 +32,7 @@ local function wherein(item)
 			if v == "default:stone" then
 				return true
 			end
-			if v == "everness:forsaken_desert_stone" then
+			if v == "everness:mineral_cave_stone" then
 				return true
 			end
 		end


### PR DESCRIPTION
Closes https://github.com/joe7575/techage/issues/187 Uses mineral_cave_stone since it drops relevant items and the other types of stone do not.