### PR TITLE
add a recipe to convert iron ingot to steel using the industrial furnace

### DIFF
--- a/furnace/recipes.lua
+++ b/furnace/recipes.lua
@@ -37,6 +37,11 @@ if techage.modified_recipes_enabled then
 		recipe = {"default:coal_lump", "default:iron_lump", "default:iron_lump", "default:iron_lump"},
 		time = 4,
 	})
+	techage.furnace.register_recipe({
+		output = "default:steel_ingot 4",
+		recipe = {"default:coal_lump", "techage:iron_ingot", "techage:iron_ingot", "techage:iron_ingot"},
+		time = 4,
+	})
 end
 
 if minetest.global_exists("wielded_light") then


### PR DESCRIPTION
It seems like it should be possible to convert iron ingot to steel in the industrial furnace, and a recipe to do so could be useful in the event that you've accidentally created too much iron ingot which is harder to store than steel since you can't make iron block.