### PR TITLE
Changed capacity of oven.

### DIFF
--- a/basis/fuel_lib.lua
+++ b/basis/fuel_lib.lua
@@ -23,7 +23,7 @@ local Burntime = techage.firebox.Burntime
 
 techage.fuel = {}
 
-local CAPACITY = 50
+local CAPACITY = techage.volume_barrel * 5
 local BLOCKING_TIME = 0.3 -- 300ms
 
 techage.fuel.CAPACITY = CAPACITY


### PR DESCRIPTION
If you have an higher value than 50 for a barrel, the punching with a barrel on an oven will not work again. This change makes it, that you can every time punch 5 barrels to an oven, independent of the volume of a barrel.