### PR TITLE
Add `no_silktouch` group to bruning lighters

### DIFF
--- a/iron_age/lighter.lua
+++ b/iron_age/lighter.lua
@@ -32,7 +32,7 @@ minetest.register_node("techage:lighter_burn", {
 	drop = "",
 	light_source = 10,
 	is_ground_content = false,
-	groups = {crumbly = 3, snappy = 3, oddly_breakable_by_hand = 1, not_in_creative_inventory=1},
+	groups = {crumbly = 3, snappy = 3, oddly_breakable_by_hand = 1, not_in_creative_inventory = 1, no_silktouch = 1},
 	sounds = default.node_sound_dirt_defaults(),
 })
 
@@ -56,7 +56,7 @@ minetest.register_node("techage:coal_lighter_burn", {
 	drop = "",
 	light_source = 10,
 	is_ground_content = false,
-	groups = {crumbly = 3, snappy = 3, oddly_breakable_by_hand = 1, not_in_creative_inventory=1},
+	groups = {crumbly = 3, snappy = 3, oddly_breakable_by_hand = 1, not_in_creative_inventory = 1, no_silktouch = 1},
 	sounds = default.node_sound_dirt_defaults(),
 })
 


### PR DESCRIPTION
Without this group, players can obtain burning lighters when using ethereal's crystal shovel.

Ethereal documetation: https://codeberg.org/tenplus1/ethereal/src/commit/01b223c5ddb312832470fa44995705ea3e87f8b4/api.txt#L40-L41
Related: https://github.com/Archtec-io/bugtracker/issues/239